### PR TITLE
Nuevos test para Orquestador y método Inicializar

### DIFF
--- a/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 
 namespace LumbApp.Expertos.ExpertoSI {
-    public class ExpertoSI {
+    public class ExpertoSI:IExpertoSI {
         private IConectorSI sensoresInternos;
 
         public Capa TejidoAdiposo = new Capa();

--- a/LumbApp/Expertos/ExpertoSI/IExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/IExpertoSI.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace LumbApp.Expertos.ExpertoSI {
-    interface IExpertoSI {
+    public interface IExpertoSI {
         event EventHandler<CambioSIEventArgs> CambioSI;
         bool Inicializar ();
         bool IniciarSimulacion ();

--- a/LumbApp/GUI/GUIController.cs
+++ b/LumbApp/GUI/GUIController.cs
@@ -9,10 +9,11 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using LumbApp.Expertos.ExpertoZE;
+using LumbApp.Conectores.ConectorFS;
 
 namespace LumbApp.GUI
 {
-    public class GUIController
+    public class GUIController : IGUIController
     {
         private Orquestador.Orquestador _orquestador { get; set; }
         private MainWindow MainWindow { get; set; }
@@ -35,7 +36,7 @@ namespace LumbApp.GUI
             SensorsCheckPage = new SensorsCheck(this);
             MainWindow.NavigationService.Navigate(SensorsCheckPage);
             SensorsCheckPage.MostrarCheckeandoSensores();
-            _orquestador = new Orquestador.Orquestador(this);
+            _orquestador = new Orquestador.Orquestador(this, new ConectorFS());
             _orquestador.Inicializar();
         }
 

--- a/LumbApp/GUI/IGUIController.cs
+++ b/LumbApp/GUI/IGUIController.cs
@@ -1,0 +1,15 @@
+﻿using LumbApp.Expertos.ExpertoZE;
+
+namespace LumbApp.GUI
+{
+    public interface IGUIController
+    {
+        void Inicializar();
+        void CheckearSensores();
+        void MostrarErrorDeConexion(string mensaje);
+        void SolicitarDatosPracticante();
+        void MostrarCambioZE(CambioZEEventArgs e);
+        void IniciarSimulacionModoEvaluacion();
+        void IniciarSimulacionModoGuiado();
+    }
+}

--- a/LumbApp/LumbApp.csproj
+++ b/LumbApp/LumbApp.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Expertos\ExpertoZE\test\Constants.cs" />
     <Compile Include="Expertos\ExpertoZE\test\MainWindow.xaml.cs" />
     <Compile Include="Expertos\ExpertoZE\ZonaEsteril.cs" />
+    <Compile Include="GUI\IGUIController.cs" />
     <Compile Include="GUI\MainWindow.xaml.cs" />
     <Compile Include="GUI\PasosPreparacion.xaml.cs" />
     <Compile Include="GUI\SimulacionModoGuiado.cs" />

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -14,8 +14,8 @@ namespace LumbApp.Orquestador
     public class Orquestador : IOrquestador {
 		public IGUIController IGUIController { get; set; }
 
-		private ExpertoZE expertoZE;
-		private ExpertoSI expertoSI;
+		private IExpertoZE expertoZE;
+		private IExpertoSI expertoSI;
 
 		private Models.DatosPracticante datosPracticante;
 		private ModoSimulacion modoSeleccionado;
@@ -138,12 +138,17 @@ namespace LumbApp.Orquestador
 			IGUIController.MostrarCambioZE(e);
 		}
 
-        public ExpertoSI GetExpertoSI () {
+        public IExpertoSI GetExpertoSI () {
 			return expertoSI;
         }
-		public void SetExpertoSI (ExpertoSI exp) {
+		public void SetExpertoSI (IExpertoSI exp) {
 			this.expertoSI = exp;
         }
 
-    }
+		public void SetExpertoZE(IExpertoZE exp)
+		{
+			this.expertoZE = exp;
+		}
+
+	}
 }

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace LumbApp.Orquestador
 {
     public class Orquestador : IOrquestador {
-		public GUIController GUIController { get; set; }
+		public IGUIController IGUIController { get; set; }
 
 		private ExpertoZE expertoZE;
 		private ExpertoSI expertoSI;
@@ -27,21 +27,18 @@ namespace LumbApp.Orquestador
 		/// Constructor del Orquestrador.
 		/// Se encarga de construir los expertos y la GUI manejando para manejar la comunicación entre ellos.
 		/// </summary>
-		public Orquestador (GUIController gui) {
+		public Orquestador (IGUIController gui, IConectorFS conectorFS) {
 			if (gui == null)
 				throw new Exception("Gui no puede ser null. Necesito un GUIController para crear un Orquestador.");
-			
-			GUIController = gui;
-
-			IConectorFS conectorFs = new ConectorFS();
+			IGUIController = gui;
 			Calibracion calibracion;
 			try
 			{
-				calibracion = conectorFs.LevantarArchivoDeTextoComoObjeto<Calibracion>("./zonaEsteril.json");
+				calibracion = conectorFS.LevantarArchivoDeTextoComoObjeto<Calibracion>("./zonaEsteril.json");
 			}catch(Exception e){
 				Console.WriteLine(e);
 				//Acá debería haber un nuevo mensaje por pantalla que me permita quitar las app, esto es incluso antes de la inicialización, asíq ue no puedo reintentar.
-				throw new Exception("Error al tratar de cargar el archivo de calibración.");
+				throw new Exception("Error al tratar de cargar el archivo de calibracion.");
 			}
 			conectorKinect = new ConectorKinect();
 			expertoZE = new ExpertoZE(conectorKinect, calibracion);
@@ -70,9 +67,9 @@ namespace LumbApp.Orquestador
 
 
 			if(modoSeleccionado == ModoSimulacion.ModoGuiado)
-				GUIController.IniciarSimulacionModoGuiado();
+				IGUIController.IniciarSimulacionModoGuiado();
 			else
-				GUIController.IniciarSimulacionModoEvaluacion();
+				IGUIController.IniciarSimulacionModoEvaluacion();
 		}
 
 		/// <summary>
@@ -99,10 +96,10 @@ namespace LumbApp.Orquestador
 				}
 
 				//Mostrar pantalla de ingreso de datos
-				GUIController.SolicitarDatosPracticante();
+				IGUIController.SolicitarDatosPracticante();
 
 			} catch (Exception ex) {
-				GUIController.MostrarErrorDeConexion(ex.Message);
+				IGUIController.MostrarErrorDeConexion(ex.Message);
 			}
 			
 		}
@@ -138,7 +135,7 @@ namespace LumbApp.Orquestador
 		private void CambioZE(object sender, CambioZEEventArgs e) {
 			//comunicar los cambios a la GUI levantando un evento
 			//Decidir que comunicamos dependiendo del modo
-			GUIController.MostrarCambioZE(e);
+			IGUIController.MostrarCambioZE(e);
 		}
 
         public ExpertoSI GetExpertoSI () {

--- a/UnitTestLumbapp/UnitTestOrquestador.cs
+++ b/UnitTestLumbapp/UnitTestOrquestador.cs
@@ -24,42 +24,6 @@ namespace UnitTestLumbapp {
             Orquestador orq = new Orquestador(null, null);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(Exception),
-            "No se pudo detectar correctamente los sensores internos.")]
-        public void TestInicializarErrAsync () {
-            //Mock<ExpertoSI> exp = new Mock<ExpertoSI>();
-
-            //exp.Setup(x => x.Inicializar()).Returns(false);
-
-
-            Mock<IOrquestador> orq = new Mock<IOrquestador>();
-            //orq.Object.SetExpertoSI(exp.Object);
-            orq.Setup(x => x.Inicializar()).Throws(new Exception("No se pudo detectar correctamente los sensores internos."));
-
-            orq.Object.Inicializar();
-        }
-        /// <summary>
-        /// provisorio
-        /// </summary>
-        [TestMethod]
-        public void CrearOrquestadorOk()
-        {
-            String textToBeReturned = "{\"zonaEsteril\":[{\"X\":-0.0531591699,\"Y\":-0.191040874,\"Z\":0.949000061},{\"X\":0.0752977654,\"Y\":-0.116173707,\"Z\":1.22900009},{\"X\":0.268609017,\"Y\":-0.144120455,\"Z\":1.11400008},{\"X\":0.140152082,\"Y\":-0.218987614,\"Z\":0.834000051},{\"X\":-0.0564637221,\"Y\":0.0991351306,\"Z\":0.872928083},{\"X\":0.0719932094,\"Y\":0.17400229,\"Z\":1.15292811},{\"X\":0.265304476,\"Y\":0.146055549,\"Z\":1.0379281},{\"X\":0.136847526,\"Y\":0.0711883903,\"Z\":0.757928073}]}";
-            Mock<IFileSystem> filesystem = new Mock<IFileSystem>();
-            filesystem.Setup(x => x.File.ReadAllText(It.IsAny<String>())).Returns(textToBeReturned);
-            ConectorFS conector = new ConectorFS(filesystem.Object);
-            Calibracion calibracion = conector.LevantarArchivoDeTextoComoObjeto<Calibracion>("C:\\file.txt");
-            ExpertoZE expertoZE;
-            ExpertoSI expertoSI;
-            IConectorKinect conectorKinect;
-            IConectorSI conectorSI;
-            conectorKinect = new ConectorKinect();
-            expertoZE = new ExpertoZE(conectorKinect, calibracion);
-            conectorSI = new ConectorSI();
-            expertoSI = new ExpertoSI(conectorSI);
-        }
-
         /// <summary>
         /// Test que prueba el caso de intentar crear un orquestador con GUI, pero incapaz de levantar un objeto calibración, generando una exception
         /// </summary>
@@ -75,11 +39,70 @@ namespace UnitTestLumbapp {
         [TestMethod]
         public void TestConstructorOK()
         {
+            Mock<IGUIController> gui = new Mock<IGUIController>();
+            IOrquestador orq = new Orquestador(gui.Object, mockedConectorFS());
+        }
+
+        [TestMethod]
+        public void TestInicializarOk()
+        {
+            Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
+            Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
+
+            expSI.Setup(x => x.Inicializar()).Returns(true);
+            expZE.Setup(x => x.Inicializar()).Returns(true);
+
+            Mock<IGUIController> gui = new Mock<IGUIController>();
+            Orquestador orq = new Orquestador(gui.Object, mockedConectorFS());
+            orq.SetExpertoSI(expSI.Object);
+            orq.SetExpertoZE(expZE.Object);
+
+            orq.Inicializar();
+            gui.Verify(x => x.SolicitarDatosPracticante(), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestInicializarSIErrAsyncInSI()
+        {
+            Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
+            Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
+
+            expSI.Setup(x => x.Inicializar()).Returns(false);
+            expZE.Setup(x => x.Inicializar()).Returns(true);
+
+            Mock<IGUIController> gui = new Mock<IGUIController>();
+            Orquestador orq = new Orquestador(gui.Object, mockedConectorFS());
+            orq.SetExpertoSI(expSI.Object);
+            orq.SetExpertoZE(expZE.Object);
+
+            orq.Inicializar();
+            gui.Verify(x => x.MostrarErrorDeConexion(It.IsAny<String>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestInicializarSIErrAsyncInZE()
+        {
+            Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
+            Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
+
+            expSI.Setup(x => x.Inicializar()).Returns(true);
+            expZE.Setup(x => x.Inicializar()).Returns(false);
+
+            Mock<IGUIController> gui = new Mock<IGUIController>();
+            Orquestador orq = new Orquestador(gui.Object, mockedConectorFS());
+            orq.SetExpertoSI(expSI.Object);
+            orq.SetExpertoZE(expZE.Object);
+
+            orq.Inicializar();
+            gui.Verify(x => x.MostrarErrorDeConexion(It.IsAny<String>()), Times.Once);
+        }
+
+        private ConectorFS mockedConectorFS()
+        {
             String textToBeReturned = "{\"zonaEsteril\":[{\"X\":-0.0531591699,\"Y\":-0.191040874,\"Z\":0.949000061},{\"X\":0.0752977654,\"Y\":-0.116173707,\"Z\":1.22900009},{\"X\":0.268609017,\"Y\":-0.144120455,\"Z\":1.11400008},{\"X\":0.140152082,\"Y\":-0.218987614,\"Z\":0.834000051},{\"X\":-0.0564637221,\"Y\":0.0991351306,\"Z\":0.872928083},{\"X\":0.0719932094,\"Y\":0.17400229,\"Z\":1.15292811},{\"X\":0.265304476,\"Y\":0.146055549,\"Z\":1.0379281},{\"X\":0.136847526,\"Y\":0.0711883903,\"Z\":0.757928073}]}";
             Mock<IFileSystem> filesystem = new Mock<IFileSystem>();
             filesystem.Setup(x => x.File.ReadAllText(It.IsAny<String>())).Returns(textToBeReturned);
-            Mock<IGUIController> gui = new Mock<IGUIController>();
-            IOrquestador orq = new Orquestador(gui.Object, new ConectorFS(filesystem.Object));
+            return new ConectorFS(filesystem.Object);
         }
     }
 }

--- a/UnitTestLumbapp/UnitTestOrquestador.cs
+++ b/UnitTestLumbapp/UnitTestOrquestador.cs
@@ -4,6 +4,12 @@ using Moq;
 using System.Threading.Tasks;
 using LumbApp.Orquestador;
 using LumbApp.GUI;
+using LumbApp.Conectores.ConectorKinect;
+using LumbApp.Expertos.ExpertoZE;
+using LumbApp.Expertos.ExpertoSI;
+using LumbApp.Conectores.ConectorSI;
+using System.IO.Abstractions;
+using LumbApp.Conectores.ConectorFS;
 
 namespace UnitTestLumbapp {
     [TestClass]
@@ -15,7 +21,7 @@ namespace UnitTestLumbapp {
         [ExpectedException(typeof(Exception),
             "Gui no puede ser null. Necesito un GUIController para crear un Orquestador.")]
         public void TestConstructorNull () {
-            Orquestador orq = new Orquestador(null);
+            Orquestador orq = new Orquestador(null, null);
         }
 
         [TestMethod]
@@ -33,6 +39,47 @@ namespace UnitTestLumbapp {
 
             orq.Object.Inicializar();
         }
-        
+        /// <summary>
+        /// provisorio
+        /// </summary>
+        [TestMethod]
+        public void CrearOrquestadorOk()
+        {
+            String textToBeReturned = "{\"zonaEsteril\":[{\"X\":-0.0531591699,\"Y\":-0.191040874,\"Z\":0.949000061},{\"X\":0.0752977654,\"Y\":-0.116173707,\"Z\":1.22900009},{\"X\":0.268609017,\"Y\":-0.144120455,\"Z\":1.11400008},{\"X\":0.140152082,\"Y\":-0.218987614,\"Z\":0.834000051},{\"X\":-0.0564637221,\"Y\":0.0991351306,\"Z\":0.872928083},{\"X\":0.0719932094,\"Y\":0.17400229,\"Z\":1.15292811},{\"X\":0.265304476,\"Y\":0.146055549,\"Z\":1.0379281},{\"X\":0.136847526,\"Y\":0.0711883903,\"Z\":0.757928073}]}";
+            Mock<IFileSystem> filesystem = new Mock<IFileSystem>();
+            filesystem.Setup(x => x.File.ReadAllText(It.IsAny<String>())).Returns(textToBeReturned);
+            ConectorFS conector = new ConectorFS(filesystem.Object);
+            Calibracion calibracion = conector.LevantarArchivoDeTextoComoObjeto<Calibracion>("C:\\file.txt");
+            ExpertoZE expertoZE;
+            ExpertoSI expertoSI;
+            IConectorKinect conectorKinect;
+            IConectorSI conectorSI;
+            conectorKinect = new ConectorKinect();
+            expertoZE = new ExpertoZE(conectorKinect, calibracion);
+            conectorSI = new ConectorSI();
+            expertoSI = new ExpertoSI(conectorSI);
+        }
+
+        /// <summary>
+        /// Test que prueba el caso de intentar crear un orquestador con GUI, pero incapaz de levantar un objeto calibración, generando una exception
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(Exception),
+            "Error al tratar de cargar el archivo de calibracion.")]
+        public void TestConstructorSinCalibracion()
+        {
+            Mock<IGUIController> gui = new Mock<IGUIController>();
+            IOrquestador orq = new Orquestador(gui.Object, null);
+        }
+
+        [TestMethod]
+        public void TestConstructorOK()
+        {
+            String textToBeReturned = "{\"zonaEsteril\":[{\"X\":-0.0531591699,\"Y\":-0.191040874,\"Z\":0.949000061},{\"X\":0.0752977654,\"Y\":-0.116173707,\"Z\":1.22900009},{\"X\":0.268609017,\"Y\":-0.144120455,\"Z\":1.11400008},{\"X\":0.140152082,\"Y\":-0.218987614,\"Z\":0.834000051},{\"X\":-0.0564637221,\"Y\":0.0991351306,\"Z\":0.872928083},{\"X\":0.0719932094,\"Y\":0.17400229,\"Z\":1.15292811},{\"X\":0.265304476,\"Y\":0.146055549,\"Z\":1.0379281},{\"X\":0.136847526,\"Y\":0.0711883903,\"Z\":0.757928073}]}";
+            Mock<IFileSystem> filesystem = new Mock<IFileSystem>();
+            filesystem.Setup(x => x.File.ReadAllText(It.IsAny<String>())).Returns(textToBeReturned);
+            Mock<IGUIController> gui = new Mock<IGUIController>();
+            IOrquestador orq = new Orquestador(gui.Object, new ConectorFS(filesystem.Object));
+        }
     }
 }


### PR DESCRIPTION
Se cambió la creación del Orquestador para soportar los tests
En vez de:
`new Orquestador(GUIController gui)`
recibe:
`new Orquestador(GUIController gui, ConectorFS conectorFS)`