### PR TITLE
Ordenando cosas

### DIFF
--- a/LumbApp/Conectores/ConectorFS/ConectorFS.cs
+++ b/LumbApp/Conectores/ConectorFS/ConectorFS.cs
@@ -31,11 +31,13 @@ namespace LumbApp.Conectores.ConectorFS
         {
             String stringToBeSaved = JsonSerializer.Serialize<T>(objectToBeSavedAsJson);
             Console.WriteLine("FS: Objeto a ser salvado: " + stringToBeSaved);
-            try {
+            try
+            {
                 _fileSystem.File.WriteAllText(path, stringToBeSaved);
-                Console.WriteLine("FS: Archivo salvado correctamente en: "+path);
+                Console.WriteLine("FS: Archivo salvado correctamente en: " + path);
                 return true;
-            }catch(Exception e)
+            }
+            catch (Exception e)
             {
                 Console.WriteLine("FS: Exception: " + e.Message);
                 return false;
@@ -57,7 +59,7 @@ namespace LumbApp.Conectores.ConectorFS
                 Console.WriteLine("FS: Archivo levantado correctamente: " + jsonStringToRead);
                 return JsonSerializer.Deserialize<T>(jsonStringToRead);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Console.WriteLine("FS: Exception: " + e.Message);
                 return default;

--- a/LumbApp/Conectores/ConectorFS/ConectorFS.cs
+++ b/LumbApp/Conectores/ConectorFS/ConectorFS.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace LumbApp.Conectores.ConectorFS
 {
@@ -35,14 +30,14 @@ namespace LumbApp.Conectores.ConectorFS
         public bool GuardarObjectoComoArchivoDeTexto<T>(string path, T objectToBeSavedAsJson)
         {
             String stringToBeSaved = JsonSerializer.Serialize<T>(objectToBeSavedAsJson);
-            Console.WriteLine("Objeto a ser salvado: " + stringToBeSaved);
+            Console.WriteLine("FS: Objeto a ser salvado: " + stringToBeSaved);
             try {
                 _fileSystem.File.WriteAllText(path, stringToBeSaved);
-                Console.WriteLine("Archivo salvado correctamente en: "+path);
+                Console.WriteLine("FS: Archivo salvado correctamente en: "+path);
                 return true;
             }catch(Exception e)
             {
-                Console.WriteLine("Exception: " + e.Message);
+                Console.WriteLine("FS: Exception: " + e.Message);
                 return false;
             }
         }
@@ -55,16 +50,16 @@ namespace LumbApp.Conectores.ConectorFS
         /// <returns>El objeto deserializado</returns>
         public T LevantarArchivoDeTextoComoObjeto<T>(string path)
         {
-            Console.WriteLine("Levantando archivo de: " + path);
+            Console.WriteLine("FS: Levantando archivo de: " + path);
             try
             {
                 String jsonStringToRead = _fileSystem.File.ReadAllText(path);
-                Console.WriteLine("Archivo levantado correctamente: " + jsonStringToRead);
+                Console.WriteLine("FS: Archivo levantado correctamente: " + jsonStringToRead);
                 return JsonSerializer.Deserialize<T>(jsonStringToRead);
             }
             catch(Exception e)
             {
-                Console.WriteLine("Exception: " + e.Message);
+                Console.WriteLine("FS: Exception: " + e.Message);
                 return default;
             }
         }

--- a/LumbApp/Conectores/ConectorFS/IConectorFS.cs
+++ b/LumbApp/Conectores/ConectorFS/IConectorFS.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LumbApp.Conectores.ConectorFS
 {

--- a/LumbApp/Conectores/ConectorKinect/ConectorKinect.cs
+++ b/LumbApp/Conectores/ConectorKinect/ConectorKinect.cs
@@ -25,9 +25,6 @@ namespace LumbApp.Conectores.ConectorKinect
             _sensor.SkeletonStream.TrackingMode = SkeletonTrackingMode.Seated;
 
             _sensor.Start();
-
-            Console.WriteLine("Color format: " + _sensor.ColorStream.Format);
-
         }
 
         /// <summary>

--- a/LumbApp/Conectores/ConectorSI/ConectorSI.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSI.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.IO.Ports;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management;
-using System.Windows.Documents;
 
 namespace LumbApp.Conectores.ConectorSI
 {

--- a/LumbApp/Conectores/ConectorSI/ConectorSI.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSI.cs
@@ -7,7 +7,8 @@ using System.Threading.Tasks;
 using System.Management;
 using System.Windows.Documents;
 
-namespace LumbApp.Conectores.ConectorSI {
+namespace LumbApp.Conectores.ConectorSI
+{
     public class ConectorSI : IConectorSI
     {
         SerialPort mySerialPort;
@@ -15,13 +16,16 @@ namespace LumbApp.Conectores.ConectorSI {
 
         private string datosLeidos = null;
 
-        public ConectorSI () { 
+        public ConectorSI()
+        {
             sensando = false;
             datosLeidos = null;
         }
 
-        public bool Conectar () {
-            try {
+        public bool Conectar()
+        {
+            try
+            {
                 mySerialPort = new SerialPort(DetectarArduinoPort())
                 {
                     BaudRate = 9600,
@@ -40,37 +44,45 @@ namespace LumbApp.Conectores.ConectorSI {
 
                 return true;
 
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 Console.WriteLine(ex);
                 return false;
             }
 
         }
 
-        private string DetectarArduinoPort () {
+        private string DetectarArduinoPort()
+        {
             ManagementScope connectionScope = new ManagementScope();
             SelectQuery serialQuery = new SelectQuery("SELECT * FROM Win32_SerialPort");
             ManagementObjectSearcher searcher = new ManagementObjectSearcher(connectionScope, serialQuery);
 
-            try {
-                foreach (ManagementObject item in searcher.Get()) {
+            try
+            {
+                foreach (ManagementObject item in searcher.Get())
+                {
                     string desc = item["Description"].ToString();
                     string deviceId = item["DeviceID"].ToString();
 
-                    if (desc.Contains("Dispositivo")) {
+                    if (desc.Contains("Dispositivo"))
+                    {
                         return deviceId;
                     }
                 }
-            } catch (ManagementException e) {
+            }
+            catch (ManagementException e)
+            {
                 Console.WriteLine(e);
             }
 
             return null;
         }
 
-        public void ActivarSensado () { sensando = true; }
-        public void Desconectar () { mySerialPort.Close(); }
-        public void PausarSensado () { sensando = false; }
+        public void ActivarSensado() { sensando = true; }
+        public void Desconectar() { mySerialPort.Close(); }
+        public void PausarSensado() { sensando = false; }
 
         /// <summary>
         /// Evento que le indica al experto que llegaron datos al conector
@@ -83,17 +95,21 @@ namespace LumbApp.Conectores.ConectorSI {
         /// <param name="datosDelEvento">
         /// Recibe los datos de cada puerto a traves de  la clase DatosSensadosEventArgs.
         /// </param>
-        protected virtual void SiHayDatos (DatosSensadosEventArgs datosDelEvento) {
+        protected virtual void SiHayDatos(DatosSensadosEventArgs datosDelEvento)
+        {
             HayDatos?.Invoke(this, datosDelEvento);
         }
 
-        public virtual void DataReceivedHandler (object sender, SerialDataReceivedEventArgs e) {
-            if (sensando) {
+        public virtual void DataReceivedHandler(object sender, SerialDataReceivedEventArgs e)
+        {
+            if (sensando)
+            {
                 SerialPort sp = (SerialPort)sender;
 
                 datosLeidos = sp.ReadTo("$");
 
-                if (datosLeidos.Length == 12) {
+                if (datosLeidos.Length == 12)
+                {
                     //Cada vez que el conector recibe datos del arduino en medio de una simulación, llama al método SiHayDatos
                     DatosSensadosEventArgs args = new DatosSensadosEventArgs(datosLeidos);
                     SiHayDatos(args);
@@ -102,23 +118,29 @@ namespace LumbApp.Conectores.ConectorSI {
 
         }
 
-        public bool CheckearComunicacion () { //Se puede checkear que todo lo que se reciba sean 0 .... o 1 si usas eso del arduino que dijiste
+        public bool CheckearComunicacion()
+        { //Se puede checkear que todo lo que se reciba sean 0 .... o 1 si usas eso del arduino que dijiste
             String datos;
 
-            try {
-                for (int i = 0; i < 50; i++) {
+            try
+            {
+                for (int i = 0; i < 50; i++)
+                {
 
                     mySerialPort.WriteLine("p");
 
                     datos = mySerialPort.ReadTo("$");
 
-                    if (datos.Contains("1") || datos.Contains("0")) {
+                    if (datos.Contains("1") || datos.Contains("0"))
+                    {
                         return true;
                     }
 
                 }
                 return false;
-            } catch {
+            }
+            catch
+            {
                 return false;
             }
         }

--- a/LumbApp/Conectores/ConectorSI/ConectorSI.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSI.cs
@@ -22,14 +22,15 @@ namespace LumbApp.Conectores.ConectorSI {
 
         public bool Conectar () {
             try {
-                mySerialPort = new SerialPort(DetectarArduinoPort());
-
-                mySerialPort.BaudRate = 9600;
-                mySerialPort.Parity = Parity.None;
-                mySerialPort.StopBits = StopBits.One;
-                mySerialPort.DataBits = 8;
-                mySerialPort.Handshake = Handshake.None;
-                mySerialPort.RtsEnable = true;
+                mySerialPort = new SerialPort(DetectarArduinoPort())
+                {
+                    BaudRate = 9600,
+                    Parity = Parity.None,
+                    StopBits = StopBits.One,
+                    DataBits = 8,
+                    Handshake = Handshake.None,
+                    RtsEnable = true
+                };
 
                 mySerialPort.DataReceived += new SerialDataReceivedEventHandler(DataReceivedHandler);
 
@@ -83,10 +84,7 @@ namespace LumbApp.Conectores.ConectorSI {
         /// Recibe los datos de cada puerto a traves de  la clase DatosSensadosEventArgs.
         /// </param>
         protected virtual void SiHayDatos (DatosSensadosEventArgs datosDelEvento) {
-            EventHandler<DatosSensadosEventArgs> handler = HayDatos;
-            if (handler != null) {
-                handler(this, datosDelEvento);
-            }
+            HayDatos?.Invoke(this, datosDelEvento);
         }
 
         public virtual void DataReceivedHandler (object sender, SerialDataReceivedEventArgs e) {

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace LumbApp.Conectores.ConectorSI {
     public class ConectorSIMock : IConectorSI {
         private bool sensando = false;
-        private bool shouldInit;
+        private readonly bool shouldInit;
 
         public event EventHandler<DatosSensadosEventArgs> HayDatos;
 

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Conectores.ConectorSI {
-    public class ConectorSIMock : IConectorSI {
+namespace LumbApp.Conectores.ConectorSI
+{
+    public class ConectorSIMock : IConectorSI
+    {
+        private bool sensando = false;
         private readonly bool shouldInit;
 
         public event EventHandler<DatosSensadosEventArgs> HayDatos;
@@ -11,22 +17,25 @@ namespace LumbApp.Conectores.ConectorSI {
         /// Crea el Conector Mockeado.
         /// </summary>
         /// <param name="shouldInit"> Recibe un booleano que de indica si debe iniciar bien o no.</param>
-        public ConectorSIMock (bool shouldInit) { this.shouldInit = shouldInit; }
-        public bool Conectar () { return shouldInit; }
-        public void ActivarSensado () {
+        public ConectorSIMock(bool shouldInit) { this.shouldInit = shouldInit; }
+        public bool Conectar() { return shouldInit; }
+        public void ActivarSensado()
+        {
             sensando = shouldInit;
             //if (sensando)
             //    simulateAsync();
         }
-        public void Desconectar () { }
-        public void PausarSensado () { sensando = false; }
+        public void Desconectar() { }
+        public void PausarSensado() { sensando = false; }
 
-        public bool CheckearComunicacion () {
+        public bool CheckearComunicacion()
+        {
             Task.Delay(5000);
             return shouldInit;
         }
 
-        private void sendEvent (String datosSensados) {
+        private void sendEvent(String datosSensados)
+        {
             var datosDelEvento = new DatosSensadosEventArgs(datosSensados);
             HayDatos?.Invoke(this, datosDelEvento);
         }
@@ -39,7 +48,8 @@ namespace LumbApp.Conectores.ConectorSI {
         ///     3) atravieza duramadre
         /// </summary>
         /// <returns></returns>
-        private async Task simulateAsync () {
+        private async Task simulateAsync()
+        {
             //Arranca simulacion
             sensando = true;
             String datosSensados;

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace LumbApp.Conectores.ConectorSI

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -112,11 +112,5 @@ namespace LumbApp.Conectores.ConectorSI
             Console.WriteLine("Finished mocked simulation");
             sensando = false;
         }
-
-        public override bool Equals(object obj)
-        {
-            return obj is ConectorSIMock mock &&
-                   shouldInit == mock.shouldInit;
-        }
     }
 }

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace LumbApp.Conectores.ConectorSI {
     public class ConectorSIMock : IConectorSI {
-        private bool sensando = false;
         private readonly bool shouldInit;
 
         public event EventHandler<DatosSensadosEventArgs> HayDatos;

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -31,12 +31,8 @@ namespace LumbApp.Conectores.ConectorSI {
         }
 
         private void sendEvent (String datosSensados) {
-
             var datosDelEvento = new DatosSensadosEventArgs(datosSensados);
-            EventHandler<DatosSensadosEventArgs> handler = HayDatos;
-            if (handler != null) {
-                handler(this, datosDelEvento);
-            }
+            HayDatos?.Invoke(this, datosDelEvento);
         }
 
         /// <summary>
@@ -112,6 +108,12 @@ namespace LumbApp.Conectores.ConectorSI {
             await Task.Delay(5000);
             Console.WriteLine("Finished mocked simulation");
             sensando = false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ConectorSIMock mock &&
+                   shouldInit == mock.shouldInit;
         }
     }
 }

--- a/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSIMock.cs
@@ -20,7 +20,7 @@ namespace LumbApp.Conectores.ConectorSI {
         public void ActivarSensado () {
             sensando = shouldInit;
             if (sensando)
-                simulateAsync();
+                _ = simulateAsync();
         }
         public void Desconectar () { }
         public void PausarSensado () { sensando = false; }

--- a/LumbApp/Conectores/ConectorSI/DatosSensadosEventArgs.cs
+++ b/LumbApp/Conectores/ConectorSI/DatosSensadosEventArgs.cs
@@ -4,10 +4,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Conectores.ConectorSI {
-    public class DatosSensadosEventArgs : EventArgs {
+namespace LumbApp.Conectores.ConectorSI
+{
+    public class DatosSensadosEventArgs : EventArgs
+    {
         public String datosSensados { get; private set; }
-        public DatosSensadosEventArgs (String datosNuevos) {
+        public DatosSensadosEventArgs(String datosNuevos)
+        {
             this.datosSensados = datosNuevos;
         }
     }

--- a/LumbApp/Conectores/ConectorSI/DatosSensadosEventArgs.cs
+++ b/LumbApp/Conectores/ConectorSI/DatosSensadosEventArgs.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LumbApp.Conectores.ConectorSI
 {

--- a/LumbApp/Conectores/ConectorSI/IConectorSI.cs
+++ b/LumbApp/Conectores/ConectorSI/IConectorSI.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace LumbApp.Conectores.ConectorSI
 {

--- a/LumbApp/Conectores/ConectorSI/IConectorSI.cs
+++ b/LumbApp/Conectores/ConectorSI/IConectorSI.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace LumbApp.Conectores.ConectorSI {
-    public interface IConectorSI {
-        bool Conectar ();
-        bool CheckearComunicacion ();
-        void ActivarSensado ();
-        void PausarSensado ();
-        void Desconectar ();
+namespace LumbApp.Conectores.ConectorSI
+{
+    public interface IConectorSI
+    {
+        bool Conectar();
+        bool CheckearComunicacion();
+        void ActivarSensado();
+        void PausarSensado();
+        void Desconectar();
         //Es necesario declarar el evento en la interfaz del conector para que pueda ser registrado por el experto
         event EventHandler<DatosSensadosEventArgs> HayDatos;
     }

--- a/LumbApp/Enums/ModoSimulacion.cs
+++ b/LumbApp/Enums/ModoSimulacion.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace LumbApp.Enums
 {

--- a/LumbApp/Enums/ModoSimulacion.cs
+++ b/LumbApp/Enums/ModoSimulacion.cs
@@ -19,5 +19,5 @@ namespace LumbApp.Enums
         [Display(Name = "Modo Evaluación")]
         ModoEvaluacion = 1,
     }
-   
+
 }

--- a/LumbApp/Expertos/ExpertoSI/CambioSIEventArgs.cs
+++ b/LumbApp/Expertos/ExpertoSI/CambioSIEventArgs.cs
@@ -1,9 +1,5 @@
 ﻿using LumbApp.Expertos.ExpertoSI.Utils;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LumbApp.Expertos.ExpertoSI
 {

--- a/LumbApp/Expertos/ExpertoSI/CambioSIEventArgs.cs
+++ b/LumbApp/Expertos/ExpertoSI/CambioSIEventArgs.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI {
-    public class CambioSIEventArgs : EventArgs {
+namespace LumbApp.Expertos.ExpertoSI
+{
+    public class CambioSIEventArgs : EventArgs
+    {
         /// <summary>
         /// Tejido-Adiposo: posicion 2 - (Arduino posicion 0)
         /// </summary>
@@ -51,7 +53,8 @@ namespace LumbApp.Expertos.ExpertoSI {
 
         public CambioSIEventArgs(Capa tejidoAdiposo, Vertebra L2, VertebraL3 L3, VertebraL4 L4, Vertebra L5, Capa Duramadre,
             bool AhoraTejidoAdiposo, bool AhoraL2, bool AhoraL3, bool AhoraL4, bool AhoraL5, bool AhoraDuramadre,
-            bool CaminoIncorrecto) {
+            bool CaminoIncorrecto)
+        {
 
             this.TejidoAdiposo = tejidoAdiposo;
             this.L2 = L2;
@@ -70,7 +73,8 @@ namespace LumbApp.Expertos.ExpertoSI {
             this.CaminoIncorrecto = CaminoIncorrecto;
         }
 
-        public void MostrarCambios () {
+        public void MostrarCambios()
+        {
             Console.WriteLine("Tejido Adiposo:  Estado: " + TejidoAdiposo.Estado + "    Veces Atravesada: " + TejidoAdiposo.VecesAtravesada);
             Console.WriteLine("L2:  Estado: " + L2.Estado + "    Veces Rozada: " + L2.VecesRozada);
             Console.WriteLine("L3:  Estado: " + L3.Estado + "    Veces Rozada: " + L3.VecesRozada + "   Sector: " + L3.Sector);

--- a/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
@@ -2,8 +2,10 @@
 using LumbApp.Expertos.ExpertoSI.Utils;
 using System;
 
-namespace LumbApp.Expertos.ExpertoSI {
-    public class ExpertoSI : IExpertoSI{
+namespace LumbApp.Expertos.ExpertoSI
+{
+    public class ExpertoSI : IExpertoSI
+    {
         private readonly IConectorSI sensoresInternos;
 
         private readonly Capa TejidoAdiposo = new Capa();
@@ -30,7 +32,8 @@ namespace LumbApp.Expertos.ExpertoSI {
 
         CambioSIEventArgs args;
 
-        public ExpertoSI (IConectorSI sensoresInternos) {
+        public ExpertoSI(IConectorSI sensoresInternos)
+        {
             if (sensoresInternos == null)
                 throw new Exception("Sensores no puede ser null. Necesito un conector a los sensores para crear un experto en sensores internos");
             this.sensoresInternos = sensoresInternos;
@@ -40,12 +43,16 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// Método que inicializa las variables, incluyendo el conector.
         /// </summary>
         /// <returns> Si todo sale bien, devuelve true sino devuelve false. </returns>
-        public bool Inicializar () {
+        public bool Inicializar()
+        {
             sensoresInternos.HayDatos += HayDatosNuevos; //suscripción al evento HayDatos
-            try {
+            try
+            {
                 if (sensoresInternos.Conectar())
                     _comunicacionCheckeada = sensoresInternos.CheckearComunicacion();
-            } catch {
+            }
+            catch
+            {
                 Console.WriteLine("SI: No pude inicializar el Experto en Sensores internos por error con el Arduino");
                 return false;
             }
@@ -58,8 +65,10 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// Inicia el sensado interno.
         /// </summary>
         /// <returns></returns>
-        public bool IniciarSimulacion () {
-            if (_comunicacionCheckeada) {
+        public bool IniciarSimulacion()
+        {
+            if (_comunicacionCheckeada)
+            {
                 _simulando = true;
                 sensoresInternos.ActivarSensado();
                 Console.WriteLine("SI: Simulación iniciada");
@@ -71,15 +80,18 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// <summary>
         /// Finaliza el sensado.
         /// </summary>
-        public void Finalizar () {
-            if (_comunicacionCheckeada) {
+        public void Finalizar()
+        {
+            if (_comunicacionCheckeada)
+            {
                 _comunicacionCheckeada = false;
                 sensoresInternos.Desconectar();
             }
             Console.WriteLine("SI: Finalizado");
         }
 
-        public InformeSI TerminarSimulacion () {
+        public InformeSI TerminarSimulacion()
+        {
             if (!_simulando)
                 return new InformeSI(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
@@ -98,7 +110,8 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// <summary>
         /// Vuelve Capas, Vertebras y estadisticas al estado inicial.
         /// </summary>
-        private void Resetear () {
+        private void Resetear()
+        {
             TejidoAdiposo.Resetear();
             L2.Resetear();
             L3.Resetear();
@@ -128,7 +141,8 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// <param name="datosCambioSI">
         /// Recibe los datos del Regsitro de Estado actual y el anterior a traves de la clase CambioSIEventArgs.
         /// </param>
-        protected virtual void HayCambioSI (CambioSIEventArgs datosCambioSI) {
+        protected virtual void HayCambioSI(CambioSIEventArgs datosCambioSI)
+        {
             CambioSI?.Invoke(this, datosCambioSI);
         }
 
@@ -139,10 +153,13 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="datosSensados"></param>
-        private void HayDatosNuevos (object sender, DatosSensadosEventArgs datosSensados) {
-            if (_simulando) {
-                if (RealizarAcciones(datosSensados.datosSensados)) {
-                    args = new CambioSIEventArgs(TejidoAdiposo, L2, L3, L4, L5, Duramadre, 
+        private void HayDatosNuevos(object sender, DatosSensadosEventArgs datosSensados)
+        {
+            if (_simulando)
+            {
+                if (RealizarAcciones(datosSensados.datosSensados))
+                {
+                    args = new CambioSIEventArgs(TejidoAdiposo, L2, L3, L4, L5, Duramadre,
                         AhoraTejidoAdiposo, AhoraL2, AhoraL3, AhoraL4, AhoraL5, AhoraDuramadre,
                         CaminoIncorrecto);
 
@@ -164,113 +181,154 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// </summary>
         /// <param name="datosSensados"> string que contiene los datos sensados. </param>
         /// <returns> Retorna true si hubo un cambio de estado en al menos alguna vertebra o capa. </returns>
-        private bool RealizarAcciones (string datosSensados) {
+        private bool RealizarAcciones(string datosSensados)
+        {
             bool Cambio = false;
             bool CaminoCorrecto = false;
             CaminoIncorrecto = false;
 
             //Camino CORRECTO - TEJIDO ADIPOSO
-            if (datosSensados[2] == '0') {
-                if (TejidoAdiposo.Atravesar()) {
+            if (datosSensados[2] == '0')
+            {
+                if (TejidoAdiposo.Atravesar())
+                {
                     AhoraTejidoAdiposo = true;
                     CaminoCorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (TejidoAdiposo.Abandonar())
                     AhoraTejidoAdiposo = true;
             }
 
             //Camino INCORRECTO - L2
-            if (datosSensados[3] == '0') {
-                if (L2.Rozar()) {
+            if (datosSensados[3] == '0')
+            {
+                if (L2.Rozar())
+                {
                     AhoraL2 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L2.Abandonar())
                     AhoraL2 = true;
             }
 
             //Camino INCORRECTO - L3 ARRIBA
-            if (datosSensados[4] == '0') {
-                if (L3.RozarSector(VertebraL3.Sectores.Arriba)) {
+            if (datosSensados[4] == '0')
+            {
+                if (L3.RozarSector(VertebraL3.Sectores.Arriba))
+                {
                     AhoraL3 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L3.AbandonarSector(VertebraL3.Sectores.Arriba))
                     AhoraL3 = true;
             }
             //Camino INCORRECTO - L3 ABAJO
-            if (datosSensados[5] == '0') {
-                if (L3.RozarSector(VertebraL3.Sectores.Abajo)) {
+            if (datosSensados[5] == '0')
+            {
+                if (L3.RozarSector(VertebraL3.Sectores.Abajo))
+                {
                     AhoraL3 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L3.AbandonarSector(VertebraL3.Sectores.Abajo))
                     AhoraL3 = true;
             }
 
             //Camino INCORRECTO - L4 ARRIBA IZQUIERDA
-            if (datosSensados[6] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.ArribaIzquierda)) {
+            if (datosSensados[6] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.ArribaIzquierda))
+                {
                     AhoraL4 = true;
-                    CaminoIncorrecto = true; 
+                    CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.ArribaIzquierda))
                     AhoraL4 = true;
             }
             //Camino INCORRECTO - L4 ARRIBA DERECHA 
-            if (datosSensados[7] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.ArribaDerecha)) {
+            if (datosSensados[7] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.ArribaDerecha))
+                {
                     AhoraL4 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.ArribaDerecha))
                     AhoraL4 = true;
             }
             //Camino CORRECTO - L4 ARRIBA CENTRO
-            if (datosSensados[8] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.ArribaCentro)) {
+            if (datosSensados[8] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.ArribaCentro))
+                {
                     AhoraL4 = true;
                     CaminoCorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.ArribaCentro))
                     AhoraL4 = true;
             }
             //Camino INCORRECTO - L4 ABAJO
-            if (datosSensados[9] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.Abajo)) {
+            if (datosSensados[9] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.Abajo))
+                {
                     AhoraL4 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.Abajo))
                     AhoraL4 = true;
             }
 
             //Camino INCORRECTO - L5
-            if (datosSensados[10] == '0') {
-                if (L5.Rozar()) {
+            if (datosSensados[10] == '0')
+            {
+                if (L5.Rozar())
+                {
                     AhoraL5 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L5.Abandonar())
                     AhoraL5 = true;
             }
 
             //Camino CORRECTO - DURAMADRE
-            if (datosSensados[11] == '0') {
-                if (Duramadre.Atravesar()) {
+            if (datosSensados[11] == '0')
+            {
+                if (Duramadre.Atravesar())
+                {
                     AhoraDuramadre = true;
                     CaminoCorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (Duramadre.Abandonar())
                     AhoraDuramadre = true;
             }
@@ -280,10 +338,11 @@ namespace LumbApp.Expertos.ExpertoSI {
 
             if (CaminoIncorrecto)
                 VecesCaminoIncorrecto++;
-            else if (CaminoCorrecto && (TejidoAdiposo.Estado == Capa.Estados.AtravesandoNuevamente || 
-                L4.Estado == VertebraL4.Estados.RozandoNuevamente || 
-                Duramadre.Estado == Capa.Estados.AtravesandoNuevamente || Duramadre.Estado == Capa.Estados.Atravesando)) {
-                
+            else if (CaminoCorrecto && (TejidoAdiposo.Estado == Capa.Estados.AtravesandoNuevamente ||
+                L4.Estado == VertebraL4.Estados.RozandoNuevamente ||
+                Duramadre.Estado == Capa.Estados.AtravesandoNuevamente || Duramadre.Estado == Capa.Estados.Atravesando))
+            {
+
                 VecesCaminoCorrecto++;
             }
 
@@ -292,10 +351,10 @@ namespace LumbApp.Expertos.ExpertoSI {
 
         /*Declaro los siguientes get para realizar los tests del expertoSI*/
         public Capa GetTejidoAdiposo() { return TejidoAdiposo; }
-        public Vertebra GetL2 () { return L2; }
-        public VertebraL3 GetL3 () { return L3; }
-        public VertebraL4 GetL4 () { return L4; }
-        public Vertebra GetL5 () { return L5; }
-        public Capa GetDuramadre () { return Duramadre; }
+        public Vertebra GetL2() { return L2; }
+        public VertebraL3 GetL3() { return L3; }
+        public VertebraL4 GetL4() { return L4; }
+        public Vertebra GetL5() { return L5; }
+        public Capa GetDuramadre() { return Duramadre; }
     }
 }

--- a/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
@@ -1,10 +1,6 @@
-﻿using LumbApp.Conectores.ConectorKinect;
-using LumbApp.Conectores.ConectorSI;
+﻿using LumbApp.Conectores.ConectorSI;
 using LumbApp.Expertos.ExpertoSI.Utils;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace LumbApp.Expertos.ExpertoSI {
     public class ExpertoSI : IExpertoSI{
@@ -50,9 +46,11 @@ namespace LumbApp.Expertos.ExpertoSI {
                 if (sensoresInternos.Conectar())
                     _comunicacionCheckeada = sensoresInternos.CheckearComunicacion();
             } catch {
+                Console.WriteLine("SI: No pude inicializar el Experto en Sensores internos por error con el Arduino");
                 return false;
             }
-            
+
+            Console.WriteLine("SI: Inicializado");
             return _comunicacionCheckeada;
         }
 
@@ -64,6 +62,7 @@ namespace LumbApp.Expertos.ExpertoSI {
             if (_comunicacionCheckeada) {
                 _simulando = true;
                 sensoresInternos.ActivarSensado();
+                Console.WriteLine("SI: Simulación iniciada");
             }
 
             return _simulando;
@@ -77,6 +76,7 @@ namespace LumbApp.Expertos.ExpertoSI {
                 _comunicacionCheckeada = false;
                 sensoresInternos.Desconectar();
             }
+            Console.WriteLine("SI: Finalizado");
         }
 
         public InformeSI TerminarSimulacion () {
@@ -84,7 +84,6 @@ namespace LumbApp.Expertos.ExpertoSI {
                 return new InformeSI(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
             _simulando = false;
-
             sensoresInternos.PausarSensado();
 
             InformeSI informe = new InformeSI(TejidoAdiposo.VecesAtravesada, L2.VecesRozada, L3.VecesArriba, L3.VecesAbajo,
@@ -92,7 +91,7 @@ namespace LumbApp.Expertos.ExpertoSI {
                 Duramadre.VecesAtravesada, VecesCaminoCorrecto, VecesCaminoIncorrecto);
 
             Resetear();
-
+            Console.WriteLine("SI: Simulación terminada");
             return informe;
         }
 

--- a/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/ExpertoSI.cs
@@ -4,14 +4,14 @@ using System;
 
 namespace LumbApp.Expertos.ExpertoSI {
     public class ExpertoSI : IExpertoSI{
-        private IConectorSI sensoresInternos;
+        private readonly IConectorSI sensoresInternos;
 
-        private Capa TejidoAdiposo = new Capa();
-        private Vertebra L2 = new Vertebra();
-        private VertebraL3 L3 = new VertebraL3();
-        private VertebraL4 L4 = new VertebraL4();
-        private Vertebra L5 = new Vertebra();
-        private Capa Duramadre = new Capa();
+        private readonly Capa TejidoAdiposo = new Capa();
+        private readonly Vertebra L2 = new Vertebra();
+        private readonly VertebraL3 L3 = new VertebraL3();
+        private readonly VertebraL4 L4 = new VertebraL4();
+        private readonly Vertebra L5 = new Vertebra();
+        private readonly Capa Duramadre = new Capa();
 
         private bool AhoraTejidoAdiposo = false;
         private bool AhoraL2 = false;
@@ -129,10 +129,7 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// Recibe los datos del Regsitro de Estado actual y el anterior a traves de la clase CambioSIEventArgs.
         /// </param>
         protected virtual void HayCambioSI (CambioSIEventArgs datosCambioSI) {
-            EventHandler<CambioSIEventArgs> handler = CambioSI;
-            if (handler != null) {
-                handler(this, datosCambioSI);
-            }
+            CambioSI?.Invoke(this, datosCambioSI);
         }
 
         /// <summary>

--- a/LumbApp/Expertos/ExpertoSI/ExpertoSIMock.cs
+++ b/LumbApp/Expertos/ExpertoSI/ExpertoSIMock.cs
@@ -1,16 +1,13 @@
 ﻿using LumbApp.Conectores.ConectorSI;
 using LumbApp.Expertos.ExpertoSI.Utils;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace LumbApp.Expertos.ExpertoSI {
     public class ExpertoSIMock : IExpertoSI{
-        private IConectorSI sensoresInternos;
+        private readonly IConectorSI sensoresInternos;
         private bool simulando = false;
-        private bool shouldInit;
+        private readonly bool shouldInit;
 
         public Capa TejidoAdiposo = new Capa();
         public Vertebra L2 = new Vertebra();
@@ -47,10 +44,7 @@ namespace LumbApp.Expertos.ExpertoSI {
         }
 
         protected virtual void HayCambioSI (CambioSIEventArgs datosCambioSI) {
-            EventHandler<CambioSIEventArgs> handler = CambioSI;
-            if (handler != null) {
-                handler(this, datosCambioSI);
-            }
+            CambioSI?.Invoke(this, datosCambioSI);
         }
 
         public void HayDatosNuevos (object sender, DatosSensadosEventArgs datosNuevos) {
@@ -81,9 +75,7 @@ namespace LumbApp.Expertos.ExpertoSI {
             sensoresInternos.ActivarSensado();
 
             if (shouldInit)
-            {
-                simulateAsync();
-            }
+                _ = simulateAsync();
             return shouldInit;
         }
 
@@ -104,10 +96,7 @@ namespace LumbApp.Expertos.ExpertoSI {
                 AhoraTejidoAdiposo, AhoraL2, AhoraL3, AhoraL4, AhoraL5, AhoraDuramadre,
                 CaminoIncorrecto);
 
-            EventHandler<CambioSIEventArgs> handler = CambioSI;
-            if (handler != null) {
-                handler(this, datosCambioSI);
-            }
+            CambioSI?.Invoke(this, datosCambioSI);
         }
 
         /// <summary>

--- a/LumbApp/Expertos/ExpertoSI/ExpertoSIMock.cs
+++ b/LumbApp/Expertos/ExpertoSI/ExpertoSIMock.cs
@@ -3,8 +3,10 @@ using LumbApp.Expertos.ExpertoSI.Utils;
 using System;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI {
-    public class ExpertoSIMock : IExpertoSI{
+namespace LumbApp.Expertos.ExpertoSI
+{
+    public class ExpertoSIMock : IExpertoSI
+    {
         private readonly IConectorSI sensoresInternos;
         private bool simulando = false;
         private readonly bool shouldInit;
@@ -32,26 +34,32 @@ namespace LumbApp.Expertos.ExpertoSI {
 
         public event EventHandler<CambioSIEventArgs> CambioSI;
 
-        public ExpertoSIMock (bool shouldInit) {
+        public ExpertoSIMock(bool shouldInit)
+        {
             this.shouldInit = shouldInit;
             sensoresInternos = new ConectorSIMock(shouldInit);
         }
-        public bool Inicializar () {
+        public bool Inicializar()
+        {
             sensoresInternos.HayDatos += HayDatosNuevos;
             sensoresInternos.Conectar();
 
             return sensoresInternos.CheckearComunicacion();
         }
 
-        protected virtual void HayCambioSI (CambioSIEventArgs datosCambioSI) {
+        protected virtual void HayCambioSI(CambioSIEventArgs datosCambioSI)
+        {
             CambioSI?.Invoke(this, datosCambioSI);
         }
 
-        public void HayDatosNuevos (object sender, DatosSensadosEventArgs datosNuevos) {
-            if (simulando) {
-                if (RealizarAcciones(datosNuevos.datosSensados)) {
+        public void HayDatosNuevos(object sender, DatosSensadosEventArgs datosNuevos)
+        {
+            if (simulando)
+            {
+                if (RealizarAcciones(datosNuevos.datosSensados))
+                {
                     args = new CambioSIEventArgs(TejidoAdiposo, L2, L3, L4, L5, Duramadre,
-                        AhoraTejidoAdiposo, AhoraL2, AhoraL3, AhoraL4, AhoraL5, AhoraDuramadre, 
+                        AhoraTejidoAdiposo, AhoraL2, AhoraL3, AhoraL4, AhoraL5, AhoraDuramadre,
                         CaminoIncorrecto);
 
                     ResetearAhora();
@@ -61,7 +69,8 @@ namespace LumbApp.Expertos.ExpertoSI {
             }
         }
 
-        public void ResetearAhora () {
+        public void ResetearAhora()
+        {
             AhoraTejidoAdiposo = false;
             AhoraL2 = false;
             AhoraL3 = false;
@@ -70,7 +79,8 @@ namespace LumbApp.Expertos.ExpertoSI {
             AhoraDuramadre = false;
         }
 
-        public bool IniciarSimulacion () {
+        public bool IniciarSimulacion()
+        {
             simulando = true;
             sensoresInternos.ActivarSensado();
 
@@ -79,7 +89,8 @@ namespace LumbApp.Expertos.ExpertoSI {
             return shouldInit;
         }
 
-        public InformeSI TerminarSimulacion () {
+        public InformeSI TerminarSimulacion()
+        {
 
             if (!simulando)
                 return new InformeSI(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -89,10 +100,11 @@ namespace LumbApp.Expertos.ExpertoSI {
                 L4.VecesArribaIzquierda, L4.VecesArribaDerecha, L4.VecesArribaCentro, L4.VecesAbajo, L5.VecesRozada,
                 Duramadre.VecesAtravesada, VecesCaminoCorrecto, VecesCaminoIncorrecto);
         }
-        public void Finalizar () { }
+        public void Finalizar() { }
 
-        private void sendEvent () {
-            var datosCambioSI = new CambioSIEventArgs(TejidoAdiposo, L2, L3, L4, L5, Duramadre, 
+        private void sendEvent()
+        {
+            var datosCambioSI = new CambioSIEventArgs(TejidoAdiposo, L2, L3, L4, L5, Duramadre,
                 AhoraTejidoAdiposo, AhoraL2, AhoraL3, AhoraL4, AhoraL5, AhoraDuramadre,
                 CaminoIncorrecto);
 
@@ -108,9 +120,10 @@ namespace LumbApp.Expertos.ExpertoSI {
         ///     3) atravieza duramadre
         /// </summary>
         /// <returns></returns>
-        private async Task simulateAsync () {
+        private async Task simulateAsync()
+        {
             //Arranca simulacion
-            simulando = true; 
+            simulando = true;
 
             //************ A partir de aca escribir toda la simulacion ****************
 
@@ -183,113 +196,154 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// </summary>
         /// <param name="datosSensados"> string que contiene los datos sensados. </param>
         /// <returns> Retorna true si hubo un cambio de estado en al menos alguna vertebra o capa. </returns>
-        private bool RealizarAcciones (string datosSensados) {
+        private bool RealizarAcciones(string datosSensados)
+        {
             bool Cambio = false;
             bool CaminoCorrecto = false;
             CaminoIncorrecto = false;
 
             //Camino CORRECTO - TEJIDO ADIPOSO
-            if (datosSensados[2] == '0') {
-                if (TejidoAdiposo.Atravesar()) {
+            if (datosSensados[2] == '0')
+            {
+                if (TejidoAdiposo.Atravesar())
+                {
                     AhoraTejidoAdiposo = true;
                     CaminoCorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (TejidoAdiposo.Abandonar())
                     AhoraTejidoAdiposo = true;
             }
 
             //Camino INCORRECTO - L2
-            if (datosSensados[3] == '0') {
-                if (L2.Rozar()) {
+            if (datosSensados[3] == '0')
+            {
+                if (L2.Rozar())
+                {
                     AhoraL2 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L2.Abandonar())
                     AhoraL2 = true;
             }
 
             //Camino INCORRECTO - L3 ARRIBA
-            if (datosSensados[4] == '0') {
-                if (L3.RozarSector(VertebraL3.Sectores.Arriba)) {
+            if (datosSensados[4] == '0')
+            {
+                if (L3.RozarSector(VertebraL3.Sectores.Arriba))
+                {
                     AhoraL3 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L3.AbandonarSector(VertebraL3.Sectores.Arriba))
                     AhoraL3 = true;
             }
             //Camino INCORRECTO - L3 ABAJO
-            if (datosSensados[5] == '0') {
-                if (L3.RozarSector(VertebraL3.Sectores.Abajo)) {
+            if (datosSensados[5] == '0')
+            {
+                if (L3.RozarSector(VertebraL3.Sectores.Abajo))
+                {
                     AhoraL3 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L3.AbandonarSector(VertebraL3.Sectores.Abajo))
                     AhoraL3 = true;
             }
 
             //Camino INCORRECTO - L4 ARRIBA IZQUIERDA
-            if (datosSensados[6] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.ArribaIzquierda)) {
+            if (datosSensados[6] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.ArribaIzquierda))
+                {
                     AhoraL4 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.ArribaIzquierda))
                     AhoraL4 = true;
             }
             //Camino INCORRECTO - L4 ARRIBA DERECHA 
-            if (datosSensados[7] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.ArribaDerecha)) {
+            if (datosSensados[7] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.ArribaDerecha))
+                {
                     AhoraL4 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.ArribaDerecha))
                     AhoraL4 = true;
             }
             //Camino CORRECTO - L4 ARRIBA CENTRO
-            if (datosSensados[8] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.ArribaCentro)) {
+            if (datosSensados[8] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.ArribaCentro))
+                {
                     AhoraL4 = true;
                     CaminoCorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.ArribaCentro))
                     AhoraL4 = true;
             }
             //Camino INCORRECTO - L4 ABAJO
-            if (datosSensados[9] == '0') {
-                if (L4.RozarSector(VertebraL4.Sectores.Abajo)) {
+            if (datosSensados[9] == '0')
+            {
+                if (L4.RozarSector(VertebraL4.Sectores.Abajo))
+                {
                     AhoraL4 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L4.AbandonarSector(VertebraL4.Sectores.Abajo))
                     AhoraL4 = true;
             }
 
             //Camino INCORRECTO - L5
-            if (datosSensados[10] == '0') {
-                if (L5.Rozar()) {
+            if (datosSensados[10] == '0')
+            {
+                if (L5.Rozar())
+                {
                     AhoraL5 = true;
                     CaminoIncorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (L5.Abandonar())
                     AhoraL5 = true;
             }
 
             //Camino CORRECTO - DURAMADRE
-            if (datosSensados[11] == '0') {
-                if (Duramadre.Atravesar()) {
+            if (datosSensados[11] == '0')
+            {
+                if (Duramadre.Atravesar())
+                {
                     AhoraDuramadre = true;
                     CaminoCorrecto = true;
                 }
-            } else {
+            }
+            else
+            {
                 if (Duramadre.Abandonar())
                     AhoraDuramadre = true;
             }
@@ -301,7 +355,8 @@ namespace LumbApp.Expertos.ExpertoSI {
                 VecesCaminoIncorrecto++;
             else if (CaminoCorrecto && (TejidoAdiposo.Estado == Capa.Estados.AtravesandoNuevamente ||
                 L4.Estado == VertebraL4.Estados.RozandoNuevamente ||
-                Duramadre.Estado == Capa.Estados.AtravesandoNuevamente || Duramadre.Estado == Capa.Estados.Atravesando)) {
+                Duramadre.Estado == Capa.Estados.AtravesandoNuevamente || Duramadre.Estado == Capa.Estados.Atravesando))
+            {
 
                 VecesCaminoCorrecto++;
             }

--- a/LumbApp/Expertos/ExpertoSI/IExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/IExpertoSI.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI {
-    public interface IExpertoSI {
+namespace LumbApp.Expertos.ExpertoSI
+{
+    public interface IExpertoSI
+    {
         event EventHandler<CambioSIEventArgs> CambioSI;
-        bool Inicializar ();
-        bool IniciarSimulacion ();
-        InformeSI TerminarSimulacion ();
-        void Finalizar ();
+        bool Inicializar();
+        bool IniciarSimulacion();
+        InformeSI TerminarSimulacion();
+        void Finalizar();
     }
 }

--- a/LumbApp/Expertos/ExpertoSI/IExpertoSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/IExpertoSI.cs
@@ -1,9 +1,4 @@
-﻿using LumbApp.Expertos.ExpertoSI.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace LumbApp.Expertos.ExpertoSI
 {

--- a/LumbApp/Expertos/ExpertoSI/InformeSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/InformeSI.cs
@@ -1,6 +1,4 @@
-﻿using LumbApp.Expertos.ExpertoSI.Utils;
-
-namespace LumbApp.Expertos.ExpertoSI
+﻿namespace LumbApp.Expertos.ExpertoSI
 {
     public class InformeSI
     {

--- a/LumbApp/Expertos/ExpertoSI/InformeSI.cs
+++ b/LumbApp/Expertos/ExpertoSI/InformeSI.cs
@@ -1,7 +1,9 @@
 ﻿using LumbApp.Expertos.ExpertoSI.Utils;
 
-namespace LumbApp.Expertos.ExpertoSI {
-    public class InformeSI {
+namespace LumbApp.Expertos.ExpertoSI
+{
+    public class InformeSI
+    {
 
         public int TejidoAdiposo { get; private set; }
         public int L2 { get; private set; }
@@ -23,9 +25,10 @@ namespace LumbApp.Expertos.ExpertoSI {
         /// Cantidad de veces que se logro llegar a la duramadre sin sensar ningun error.
         /// </summary>
         public int CaminoIncorrecto;
-        
-        public InformeSI(int TejidoAdiposo, int L2, int L3Arriba, int L3Abajo, int L4ArribaIzquierda, int L4ArribaDerecha, 
-            int L4ArribaCentro, int L4Abajo, int L5, int Duramadre, int CaminoCorrecto, int CaminoIncorrecto) {
+
+        public InformeSI(int TejidoAdiposo, int L2, int L3Arriba, int L3Abajo, int L4ArribaIzquierda, int L4ArribaDerecha,
+            int L4ArribaCentro, int L4Abajo, int L5, int Duramadre, int CaminoCorrecto, int CaminoIncorrecto)
+        {
 
             this.TejidoAdiposo = TejidoAdiposo;
             this.L2 = L2;

--- a/LumbApp/Expertos/ExpertoSI/Utils/Capa.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/Capa.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace LumbApp.Expertos.ExpertoSI.Utils
+﻿namespace LumbApp.Expertos.ExpertoSI.Utils
 {
     public class Capa
     {

--- a/LumbApp/Expertos/ExpertoSI/Utils/Capa.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/Capa.cs
@@ -4,9 +4,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI.Utils {
-    public class Capa {
-        public enum Estados {
+namespace LumbApp.Expertos.ExpertoSI.Utils
+{
+    public class Capa
+    {
+        public enum Estados
+        {
             /// <summary>
             /// Inicial indica que, desde que comenzo la simulacion, la capa todavia no fue atravesada.
             /// Es decir, la aguja no la toco.
@@ -35,7 +38,8 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         public Estados Estado { get; private set; }
         public int VecesAtravesada { get; private set; }
 
-        public Capa () {
+        public Capa()
+        {
             Estado = Estados.Inicial;
             VecesAtravesada = 0;
         }
@@ -45,8 +49,10 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         /// o AtravesandoNuevamente.
         /// </summary>
         /// <returns>Si hubo cambio de estado retorna true.</returns>
-        public bool Atravesar () {
-            switch (Estado) {
+        public bool Atravesar()
+        {
+            switch (Estado)
+            {
                 case Estados.Inicial:
                     Estado = Estados.Atravesando;
                     VecesAtravesada++;
@@ -64,14 +70,16 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         /// pasa a Abandonada.
         /// </summary>
         /// <returns>Si hubo cambio de estado retorna true.</returns>
-        public bool Abandonar () {
+        public bool Abandonar()
+        {
             if (Estado == Estados.Inicial || Estado == Estados.Abandonada)
                 return false;
             Estado = Estados.Abandonada;
             return true;
         }
 
-        public void Resetear () {
+        public void Resetear()
+        {
             Estado = Estados.Inicial;
             VecesAtravesada = 0;
         }

--- a/LumbApp/Expertos/ExpertoSI/Utils/Vertebra.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/Vertebra.cs
@@ -4,10 +4,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI.Utils {
-    public class Vertebra {
-        
-        public enum Estados {
+namespace LumbApp.Expertos.ExpertoSI.Utils
+{
+    public class Vertebra
+    {
+
+        public enum Estados
+        {
             /// <summary>
             /// Inicial indica que, desde que comenzo la simulacion, la vertebra todavia no fue rozada.
             /// Es decir, la aguja no la toco.
@@ -36,7 +39,8 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         public Estados Estado { get; private set; }
         public int VecesRozada { get; private set; }
 
-        public Vertebra () {
+        public Vertebra()
+        {
             Estado = Estados.Inicial;
             VecesRozada = 0;
         }
@@ -47,8 +51,10 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         /// o RozandoNuevamente.
         /// </summary>
         /// <returns>Si hubo cambio de estado retorna true.</returns>
-        public bool Rozar () {
-            switch (Estado) {
+        public bool Rozar()
+        {
+            switch (Estado)
+            {
                 case Estados.Inicial:
                     Estado = Estados.Rozando;
                     VecesRozada = 1;
@@ -66,14 +72,16 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         /// pasa a Abandonada.
         /// </summary>
         /// <returns>Si hubo cambio de estado retorna true.</returns>
-        public bool Abandonar () {
+        public bool Abandonar()
+        {
             if (Estado == Estados.Inicial || Estado == Estados.Abandonada)
                 return false;
             Estado = Estados.Abandonada;
             return true;
         }
 
-        public void Resetear () {
+        public void Resetear()
+        {
             Estado = Estados.Inicial;
             VecesRozada = 0;
         }

--- a/LumbApp/Expertos/ExpertoSI/Utils/Vertebra.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/Vertebra.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace LumbApp.Expertos.ExpertoSI.Utils
+﻿namespace LumbApp.Expertos.ExpertoSI.Utils
 {
     public class Vertebra
     {

--- a/LumbApp/Expertos/ExpertoSI/Utils/VertebraL3.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/VertebraL3.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace LumbApp.Expertos.ExpertoSI.Utils
 {

--- a/LumbApp/Expertos/ExpertoSI/Utils/VertebraL3.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/VertebraL3.cs
@@ -5,9 +5,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI.Utils {
-    public class VertebraL3 : Vertebra {
-        public  enum Sectores {
+namespace LumbApp.Expertos.ExpertoSI.Utils
+{
+    public class VertebraL3 : Vertebra
+    {
+        public enum Sectores
+        {
 
             [Display(Name = "Arriba")]
             Arriba,
@@ -21,7 +24,8 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         public int VecesArriba { get; private set; }
         public int VecesAbajo { get; private set; }
 
-        public VertebraL3() : base() {
+        public VertebraL3() : base()
+        {
             VecesArriba = 0;
             VecesAbajo = 0;
         }
@@ -30,12 +34,15 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         /// Setea al sector de la vertebra que esta siendo rozado.
         /// </summary>
         /// <returns>Si hubo cambio de estado retorna true.</returns>
-        public bool RozarSector(Sectores sector) {
-            
-            if (Rozar()) {
+        public bool RozarSector(Sectores sector)
+        {
+
+            if (Rozar())
+            {
                 this.Sector = sector;
 
-                switch (Sector) {
+                switch (Sector)
+                {
                     case Sectores.Arriba:
                         VecesArriba++;
                         break;
@@ -49,13 +56,15 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
             return false;
         }
 
-        public bool AbandonarSector (Sectores sector) {
+        public bool AbandonarSector(Sectores sector)
+        {
             if (this.Sector == sector)
                 return base.Abandonar();
             return false;
         }
 
-        public new void Resetear () {
+        public new void Resetear()
+        {
             VecesArriba = 0;
             VecesAbajo = 0;
             base.Resetear();

--- a/LumbApp/Expertos/ExpertoSI/Utils/VertebraL4.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/VertebraL4.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace LumbApp.Expertos.ExpertoSI.Utils
 {

--- a/LumbApp/Expertos/ExpertoSI/Utils/VertebraL4.cs
+++ b/LumbApp/Expertos/ExpertoSI/Utils/VertebraL4.cs
@@ -5,9 +5,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Expertos.ExpertoSI.Utils {
-    public class VertebraL4 : Vertebra {
-        public enum Sectores {
+namespace LumbApp.Expertos.ExpertoSI.Utils
+{
+    public class VertebraL4 : Vertebra
+    {
+        public enum Sectores
+        {
 
             [Display(Name = "ArribaIzquierda")]
             ArribaIzquierda,
@@ -29,7 +32,8 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         public int VecesArribaCentro { get; private set; }
         public int VecesAbajo { get; private set; }
 
-        public VertebraL4 () : base() {
+        public VertebraL4() : base()
+        {
             VecesArribaIzquierda = 0;
             VecesArribaDerecha = 0;
             VecesArribaCentro = 0;
@@ -41,12 +45,15 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
         /// Setea al sector de la vertebra que esta siendo rozado.
         /// </summary>
         /// <returns>Si hubo cambio de estado retorna true.</returns>
-        public bool RozarSector (Sectores sector) {
-            
-            if (Rozar()) {
+        public bool RozarSector(Sectores sector)
+        {
+
+            if (Rozar())
+            {
                 this.Sector = sector;
 
-                switch (Sector) {
+                switch (Sector)
+                {
                     case Sectores.ArribaIzquierda:
                         VecesArribaIzquierda++;
                         break;
@@ -66,13 +73,15 @@ namespace LumbApp.Expertos.ExpertoSI.Utils {
             return false;
         }
 
-        public bool AbandonarSector (Sectores sector) {
+        public bool AbandonarSector(Sectores sector)
+        {
             if (this.Sector == sector)
                 return base.Abandonar();
             return false;
         }
 
-        public new void Resetear () {
+        public new void Resetear()
+        {
             VecesArribaIzquierda = 0;
             VecesArribaDerecha = 0;
             VecesArribaCentro = 0;

--- a/LumbApp/Expertos/ExpertoZE/Calibracion.cs
+++ b/LumbApp/Expertos/ExpertoZE/Calibracion.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Kinect;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LumbApp.Expertos.ExpertoZE
 {

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZE.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZE.cs
@@ -193,8 +193,7 @@ namespace LumbApp.Expertos.ExpertoZE
         private bool processHand(Joint joint, Mano mano, CambioZEEventArgs eventArgs)
         {
             //Tracking
-            bool cambioTrack = false;
-            cambioTrack = mano.ActualizarTrack(joint.TrackingState == JointTrackingState.Tracked);
+            bool cambioTrack = mano.ActualizarTrack(joint.TrackingState == JointTrackingState.Tracked);
             if (mano.Track == Mano.Tracking.Perdido)
                 return cambioTrack;
 

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZE.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZE.cs
@@ -70,11 +70,12 @@ namespace LumbApp.Expertos.ExpertoZE
             }
             catch (Exception ex)
             {
-                logger.Error(ex, "No pude inicializar el Experto en Zona Esteril por error con la Kinect");
+                Console.WriteLine("ZE: No pude inicializar el Experto en Zona Esteril por error con la Kinect. Error: " + ex);
                 inicializado = false;
                 return false;
             }
             inicializado = true;
+            Console.WriteLine("ZE: Inicializado");
             return true;
         }
 
@@ -87,13 +88,17 @@ namespace LumbApp.Expertos.ExpertoZE
         public bool IniciarSimulacion()
         {
             if (!inicializado || zonaEsteril == null)
+            {
+                Console.WriteLine("ZE: No pude iniciar la simulación. Inicialice primero");
                 return false;
+            }
 
             manoDerecha = new Mano();
             manoIzquierda = new Mano();
             zonaEsteril.Resetear();
             videoWriter = new Video();
             simulando = true;
+            Console.WriteLine("ZE: Simulación iniciada");
             return true;
         }
 
@@ -108,7 +113,7 @@ namespace LumbApp.Expertos.ExpertoZE
             if (!simulando)
                 return new InformeZE(0, 0, 0, videoWriter);
 
-            Console.WriteLine("Terminando simulacion ZE");
+            Console.WriteLine("ZE: Simulación terminada");
             simulando = false;
             return new InformeZE(zonaEsteril.Contaminacion, manoDerecha.VecesContamino, manoIzquierda.VecesContamino, videoWriter);
         }
@@ -120,6 +125,7 @@ namespace LumbApp.Expertos.ExpertoZE
         {
             kinect.Desconectar();
             simulando = false;
+            Console.WriteLine("ZE: Finalizado");
         }
         #endregion
 

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZE.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZE.cs
@@ -13,10 +13,8 @@ namespace LumbApp.Expertos.ExpertoZE
         /// </summary>
         public event EventHandler<CambioZEEventArgs> CambioZE;
 
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
-        private IConectorKinect kinect;
-        private ZonaEsteril zonaEsteril;
+        private readonly IConectorKinect kinect;
+        private readonly ZonaEsteril zonaEsteril;
 
         private Mano manoDerecha;
         private Mano manoIzquierda;

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.Kinect;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace LumbApp.Expertos.ExpertoZE

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
@@ -46,10 +46,12 @@ namespace LumbApp.Expertos.ExpertoZE
 
         private SkeletonPoint newPoint(float x, float y, float z)
         {
-            SkeletonPoint p = new SkeletonPoint();
-            p.X = x;
-            p.Y = y;
-            p.Z = z;
+            SkeletonPoint p = new SkeletonPoint
+            {
+                X = x,
+                Y = y,
+                Z = z
+            };
             return p;
         }
 
@@ -111,18 +113,22 @@ namespace LumbApp.Expertos.ExpertoZE
             await Task.Delay(2000);
             manoIzquierda.Entrar();
             zonaEsteril.Contaminar();
-            var args = new CambioZEEventArgs(manoDerecha, manoIzquierda);
-            args.VecesContaminado = zonaEsteril.Contaminacion;
-            args.ContaminadoAhora = true;
+            var args = new CambioZEEventArgs(manoDerecha, manoIzquierda)
+            {
+                VecesContaminado = zonaEsteril.Contaminacion,
+                ContaminadoAhora = true
+            };
             CambioZE.Invoke(this, args);
 
             //Ej: der entra y contamina a los 30 segundos (sendEvent no marca el contaminando ahora)
             await Task.Delay(2000);
             manoDerecha.Entrar();
             zonaEsteril.Contaminar();
-            args = new CambioZEEventArgs(manoDerecha, manoIzquierda);
-            args.VecesContaminado = zonaEsteril.Contaminacion;
-            args.ContaminadoAhora = true;
+            args = new CambioZEEventArgs(manoDerecha, manoIzquierda)
+            {
+                VecesContaminado = zonaEsteril.Contaminacion,
+                ContaminadoAhora = true
+            };
             CambioZE.Invoke(this, args);
 
             // ************** Fin seccion simulacion *************
@@ -135,8 +141,10 @@ namespace LumbApp.Expertos.ExpertoZE
 
         private void sendEvent()
         {
-            var args = new CambioZEEventArgs(manoDerecha, manoIzquierda);
-            args.VecesContaminado = zonaEsteril.Contaminacion;
+            var args = new CambioZEEventArgs(manoDerecha, manoIzquierda)
+            {
+                VecesContaminado = zonaEsteril.Contaminacion
+            };
             CambioZE.Invoke(this, args);
         }
     }

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
@@ -11,7 +11,7 @@ namespace LumbApp.Expertos.ExpertoZE
     {
         public event EventHandler<CambioZEEventArgs> CambioZE;
 
-        private bool shouldInit;
+        private readonly bool shouldInit;
         private bool simulando;
         private ZonaEsteril zonaEsteril;
         private Mano manoDerecha;

--- a/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
+++ b/LumbApp/Expertos/ExpertoZE/ExpertoZEMock.cs
@@ -40,7 +40,7 @@ namespace LumbApp.Expertos.ExpertoZE
             manoIzquierda = new Mano();
 
             if (shouldInit)
-                simulateAsync();
+                _ = simulateAsync();
             return shouldInit;
         }
 

--- a/LumbApp/Expertos/ExpertoZE/IExpertoZE.cs
+++ b/LumbApp/Expertos/ExpertoZE/IExpertoZE.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LumbApp.Expertos.ExpertoZE
 {

--- a/LumbApp/Expertos/ExpertoZE/Video.cs
+++ b/LumbApp/Expertos/ExpertoZE/Video.cs
@@ -12,8 +12,8 @@ namespace LumbApp.Expertos.ExpertoZE
         //private List<BitmapData> frames;
         private const int width = 640;
         private const int height = 480;
-        private VideoFileWriter writer;
-        private Bitmap bitmap;
+        private readonly VideoFileWriter writer;
+        private readonly Bitmap bitmap;
 
         public Video(string path)
         {

--- a/LumbApp/Expertos/ExpertoZE/test/ColorExtensions.cs
+++ b/LumbApp/Expertos/ExpertoZE/test/ColorExtensions.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Windows.Media;
-using Microsoft.Kinect;
-using System.IO;
+﻿using Microsoft.Kinect;
 using System.Windows.Media.Imaging;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/LumbApp/Expertos/ExpertoZE/test/Constants.cs
+++ b/LumbApp/Expertos/ExpertoZE/test/Constants.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media;
+﻿using System.Windows.Media;
 
 namespace KinectCoordinateMapping
 {

--- a/LumbApp/Expertos/ExpertoZE/test/MainWindow.xaml.cs
+++ b/LumbApp/Expertos/ExpertoZE/test/MainWindow.xaml.cs
@@ -85,16 +85,16 @@ namespace KinectCoordinateMapping
         {
             Point pos = e.GetPosition(camera);
             Point empty = new Point();
-            if(screenPoint1 == empty)
+            if (screenPoint1 == empty)
                 screenPoint1 = new Point(pos.X, pos.Y);
-            else if(screenPoint2 == empty)
+            else if (screenPoint2 == empty)
                 screenPoint2 = new Point(pos.X, pos.Y);
             else if (screenPoint3 == empty)
             {
                 screenPoint3 = new Point(pos.X, pos.Y);
                 calcular = true;
             }
-           
+
             Console.WriteLine("Click en " + pos);
         }
         #endregion
@@ -132,9 +132,9 @@ namespace KinectCoordinateMapping
         private SkeletonPoint cruz(SkeletonPoint a, SkeletonPoint b)
         {
             var res = new SkeletonPoint();
-            res.X = a.Y*b.Z - a.Z*b.Y; //a2b3-a3b2
-            res.Y = a.Z*b.X - a.X*b.Z; //a3b1-a1b3
-            res.Z = a.X*b.Y - a.Y*b.X; //a1b2-a2b1
+            res.X = a.Y * b.Z - a.Z * b.Y; //a2b3-a3b2
+            res.Y = a.Z * b.X - a.X * b.Z; //a3b1-a1b3
+            res.Z = a.X * b.Y - a.Y * b.X; //a1b2-a2b1
             return res;
         }
 
@@ -149,7 +149,7 @@ namespace KinectCoordinateMapping
 
         private double modulo(SkeletonPoint a)
         {
-            return Math.Sqrt(Math.Pow(a.X,2) + Math.Pow(a.Y, 2) + Math.Pow(a.Z, 2));
+            return Math.Sqrt(Math.Pow(a.X, 2) + Math.Pow(a.Y, 2) + Math.Pow(a.Z, 2));
         }
 
         private double distToPlane(SkeletonPoint centro, SkeletonPoint right, SkeletonPoint left, SkeletonPoint test)
@@ -260,8 +260,8 @@ namespace KinectCoordinateMapping
                             }
                         }
                     }
-                    
-                }  
+
+                }
             }
 
             // Body
@@ -294,13 +294,13 @@ namespace KinectCoordinateMapping
 
         private Brush setBrush(Mano data)
         {
-            if(data.Track == Mano.Tracking.Perdido)
+            if (data.Track == Mano.Tracking.Perdido)
                 return inferredJointBrush;
             if (data.Estado == Mano.Estados.Fuera || data.Estado == Mano.Estados.Inicial)
                 return trackedJointBrush;
             return inZeBrush;
         }
-        
+
         private void drawJoint(Joint joint, Brush b)
         {
             // 3D coordinates in meters

--- a/LumbApp/Expertos/ExpertoZE/test/MainWindow.xaml.cs
+++ b/LumbApp/Expertos/ExpertoZE/test/MainWindow.xaml.cs
@@ -2,7 +2,6 @@
 using LumbApp.Expertos.ExpertoZE;
 using Microsoft.Kinect;
 using System;
-using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/LumbApp/Expertos/ExpertoZE/test/MainWindow.xaml.cs
+++ b/LumbApp/Expertos/ExpertoZE/test/MainWindow.xaml.cs
@@ -113,37 +113,45 @@ namespace KinectCoordinateMapping
 
         private SkeletonPoint mas(SkeletonPoint a, SkeletonPoint b)
         {
-            var res = new SkeletonPoint();
-            res.X = a.X + b.X;
-            res.Y = a.Y + b.Y;
-            res.Z = a.Z + b.Z;
+            var res = new SkeletonPoint
+            {
+                X = a.X + b.X,
+                Y = a.Y + b.Y,
+                Z = a.Z + b.Z
+            };
             return res;
         }
 
         private SkeletonPoint menos(SkeletonPoint a, SkeletonPoint b)
         {
-            var res = new SkeletonPoint();
-            res.X = a.X - b.X;
-            res.Y = a.Y - b.Y;
-            res.Z = a.Z - b.Z;
+            var res = new SkeletonPoint
+            {
+                X = a.X - b.X,
+                Y = a.Y - b.Y,
+                Z = a.Z - b.Z
+            };
             return res;
         }
 
         private SkeletonPoint cruz(SkeletonPoint a, SkeletonPoint b)
         {
-            var res = new SkeletonPoint();
-            res.X = a.Y * b.Z - a.Z * b.Y; //a2b3-a3b2
-            res.Y = a.Z * b.X - a.X * b.Z; //a3b1-a1b3
-            res.Z = a.X * b.Y - a.Y * b.X; //a1b2-a2b1
+            var res = new SkeletonPoint
+            {
+                X = a.Y * b.Z - a.Z * b.Y, //a2b3-a3b2
+                Y = a.Z * b.X - a.X * b.Z, //a3b1-a1b3
+                Z = a.X * b.Y - a.Y * b.X //a1b2-a2b1
+            };
             return res;
         }
 
         private SkeletonPoint por(float a, SkeletonPoint b)
         {
-            var res = new SkeletonPoint();
-            res.X = a * b.X;
-            res.Y = a * b.Y;
-            res.Z = a * b.Z;
+            var res = new SkeletonPoint
+            {
+                X = a * b.X,
+                Y = a * b.Y,
+                Z = a * b.Z
+            };
             return res;
         }
 
@@ -314,9 +322,11 @@ namespace KinectCoordinateMapping
         private void draw2DPoint(ColorImagePoint colorPoint, Brush b)
         {
             // 2D coordinates in pixels
-            Point point = new Point();
-            point.X = colorPoint.X;
-            point.Y = colorPoint.Y;
+            Point point = new Point
+            {
+                X = colorPoint.X,
+                Y = colorPoint.Y
+            };
 
             drawPoint(b, point);
         }

--- a/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
@@ -15,10 +15,10 @@ namespace LumbApp.FinalFeedbacker_
 {
     public class FinalFeedbacker : IFinalFeedbacker
     {
-        private DatosPracticante _datosPracticante;
-        private OrderedDictionary _datosPractica;
-        private string _path;
-        private DateTime _fecha;
+        private readonly DatosPracticante _datosPracticante;
+        private readonly OrderedDictionary _datosPractica;
+        private readonly string _path;
+        private readonly DateTime _fecha;
 
         public FinalFeedbacker(string path, DatosPracticante datosPracticante,
             OrderedDictionary datosPractica, DateTime fecha)

--- a/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
@@ -1,16 +1,11 @@
 ﻿using iTextSharp.text;
 using iTextSharp.text.pdf;
-using LumbApp.Expertos.ExpertoSI;
-using LumbApp.Expertos.ExpertoZE;
 using LumbApp.Models;
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
+
 namespace LumbApp.FinalFeedbacker_
 {
     public class FinalFeedbacker : IFinalFeedbacker

--- a/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
@@ -11,17 +11,20 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-namespace LumbApp.FinalFeedbacker_ {
-    public class FinalFeedbacker : IFinalFeedbacker {
+namespace LumbApp.FinalFeedbacker_
+{
+    public class FinalFeedbacker : IFinalFeedbacker
+    {
         private DatosPracticante _datosPracticante;
         private OrderedDictionary _datosPractica;
         private string _path;
         private DateTime _fecha;
 
-        public FinalFeedbacker (string path, DatosPracticante datosPracticante,
-            OrderedDictionary datosPractica, DateTime fecha) {
+        public FinalFeedbacker(string path, DatosPracticante datosPracticante,
+            OrderedDictionary datosPractica, DateTime fecha)
+        {
 
-            if(path==null || path=="" || datosPracticante == null || datosPractica == null || fecha == null)
+            if (path == null || path == "" || datosPracticante == null || datosPractica == null || fecha == null)
                 throw new Exception("Los datos de entrada no peden ser nulos, los necesito para crear el informe en PDF.");
 
             this._path = path;
@@ -30,8 +33,10 @@ namespace LumbApp.FinalFeedbacker_ {
             this._fecha = fecha;
         }
 
-        public bool GenerarPDF () {
-            try {
+        public bool GenerarPDF()
+        {
+            try
+            {
                 Document doc = new Document(PageSize.A4);
                 // Indicamos donde vamos a guardar el documento
                 PdfWriter writer = PdfWriter.GetInstance(doc, new FileStream(_path, FileMode.Create));
@@ -45,7 +50,7 @@ namespace LumbApp.FinalFeedbacker_ {
                 doc.Open();
 
                 Font _standardFont = new Font(Font.FontFamily.HELVETICA, 8, Font.NORMAL, BaseColor.BLACK);
-                
+
                 Font fuenteTitulos = new Font(Font.FontFamily.COURIER, 12, Font.BOLD, BaseColor.GREEN);
                 fuenteTitulos.SetColor(0, 126, 93);
                 BaseColor backgroundTitulos = new BaseColor(186, 232, 210);
@@ -122,7 +127,7 @@ namespace LumbApp.FinalFeedbacker_ {
                 Chunk chEstadisticas = new Chunk("Información de la práctica", fuenteTitulos);
                 chEstadisticas.SetBackground(backgroundTitulos);
                 doc.Add(new Paragraph(chEstadisticas));
-                
+
                 // Creamos una tabla que contendrá los datos de la practica
                 PdfPTable tblDatosPractica = new PdfPTable(2);
                 tblDatosPractica.WidthPercentage = 100;
@@ -140,7 +145,7 @@ namespace LumbApp.FinalFeedbacker_ {
                 tblDatosPractica.AddCell(columnaDescripcion);
                 tblDatosPractica.AddCell(columnaCantidad);
 
-                foreach(DictionaryEntry de in _datosPractica)
+                foreach (DictionaryEntry de in _datosPractica)
                 {
                     columnaDescripcion = new PdfPCell(new Phrase(de.Key.ToString(), _standardFont));
                     columnaDescripcion.BorderWidth = 0;
@@ -161,11 +166,13 @@ namespace LumbApp.FinalFeedbacker_ {
                 writer.Close();
 
                 return true;
-            } catch (Exception ex){
+            }
+            catch (Exception ex)
+            {
                 Console.WriteLine("FF: no pude crear el PDF final. Error: " + ex);
                 return false;
             }
-            
+
         }
     }
 }

--- a/LumbApp/FinalFeedbacker_/IFinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/IFinalFeedbacker.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.FinalFeedbacker_ {
-    public interface IFinalFeedbacker {
-        bool GenerarPDF ();
+namespace LumbApp.FinalFeedbacker_
+{
+    public interface IFinalFeedbacker
+    {
+        bool GenerarPDF();
     }
 }

--- a/LumbApp/FinalFeedbacker_/IFinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/IFinalFeedbacker.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace LumbApp.FinalFeedbacker_
+﻿namespace LumbApp.FinalFeedbacker_
 {
     public interface IFinalFeedbacker
     {

--- a/LumbApp/GUI/GUIController.cs
+++ b/LumbApp/GUI/GUIController.cs
@@ -120,7 +120,7 @@ namespace LumbApp.GUI
         {
             ResultadosSimulacionPage = new ResultadosSimulacion(this);
             MainWindow.NavigationService.Navigate(ResultadosSimulacionPage);
-            _orquestador.TerminarSimulacion();
+            _ = _orquestador.TerminarSimulacion();
         }
 
         public void MostrarResultados( Informe informe )

--- a/LumbApp/GUI/GUIController.cs
+++ b/LumbApp/GUI/GUIController.cs
@@ -16,7 +16,8 @@ namespace LumbApp.GUI
         private SimulacionModoEvaluacion SimulacionModoEvaluacionPage { get; set; }
         private ResultadosSimulacion ResultadosSimulacionPage { get; set; }
 
-        public GUIController(MainWindow mainWindow) {
+        public GUIController(MainWindow mainWindow)
+        {
 
             MainWindow = mainWindow;
         }
@@ -37,7 +38,7 @@ namespace LumbApp.GUI
         {
             _ = _orquestador.Inicializar();  //si fallo la primera vez reintento
         }
-        
+
         public void NuevaSimulacion()
         {
             _ = _orquestador.NuevaSimulacion();  //si fallo la primera vez reintento
@@ -57,7 +58,7 @@ namespace LumbApp.GUI
         /// </summary>
         public void SolicitarDatosPracticante(string folderPath)
         {
-            IngresoDatosPracticantePage = new IngresoDatosPracticante(this,folderPath);
+            IngresoDatosPracticantePage = new IngresoDatosPracticante(this, folderPath);
             MainWindow.NavigationService.Navigate(IngresoDatosPracticantePage);
         }
 
@@ -75,7 +76,8 @@ namespace LumbApp.GUI
         /// <summary>
         /// Muestra los pasos de preparacion
         /// </summary>
-        private void MostrarPasosPreparacion() {
+        private void MostrarPasosPreparacion()
+        {
             PasosPreparacion pasosPreparacionPage = new PasosPreparacion(this);
             MainWindow.NavigationService.Navigate(pasosPreparacionPage);
         }
@@ -123,7 +125,7 @@ namespace LumbApp.GUI
             _ = _orquestador.TerminarSimulacion();
         }
 
-        public void MostrarResultados( Informe informe )
+        public void MostrarResultados(Informe informe)
         {
             ResultadosSimulacionPage.MostrarResultados(informe);
         }

--- a/LumbApp/GUI/GUIController.cs
+++ b/LumbApp/GUI/GUIController.cs
@@ -29,17 +29,17 @@ namespace LumbApp.GUI
             MainWindow.NavigationService.Navigate(SensorsCheckPage);
             SensorsCheckPage.MostrarCheckeandoSensores();
             _orquestador = new Orquestador.Orquestador(this, new ConectorFS());
-            _orquestador.Inicializar();
+            _ = _orquestador.Inicializar();
         }
 
         public void CheckearSensores()
         {
-            _orquestador.Inicializar();  //si fallo la primera vez reintento
+            _ = _orquestador.Inicializar();  //si fallo la primera vez reintento
         }
         
         public void NuevaSimulacion()
         {
-            _orquestador.NuevaSimulacion();  //si fallo la primera vez reintento
+            _ = _orquestador.NuevaSimulacion();  //si fallo la primera vez reintento
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace LumbApp.GUI
 
         public void FinalizarSimulacion()
         {
-            _orquestador.TerminarSimulacion();
+            _ = _orquestador.TerminarSimulacion();
             ResultadosSimulacionPage = new ResultadosSimulacion(this);
             MainWindow.NavigationService.Navigate(ResultadosSimulacionPage);
         }

--- a/LumbApp/GUI/IngresoDatosPracticante.xaml
+++ b/LumbApp/GUI/IngresoDatosPracticante.xaml
@@ -213,11 +213,11 @@
                         Foreground="#8a8a8a">DNI</TextBlock>
                 </local:WatermarkService.Watermark>
                 <TextBox.Resources>
-                <Style TargetType="{x:Type Border}">
-                    <Setter Property="CornerRadius" Value="25"/>
-                </Style>
-            </TextBox.Resources>
-        </TextBox>
+                    <Style TargetType="{x:Type Border}">
+                        <Setter Property="CornerRadius" Value="25"/>
+                    </Style>
+                </TextBox.Resources>
+            </TextBox>
         </AdornerDecorator>
 
         <Label Name="ErrorDni" Grid.Row="7"  Grid.Column="2" Grid.ColumnSpan="2"
@@ -240,11 +240,11 @@
                         Foreground="#8a8a8a">Mail</TextBlock>
                 </local:WatermarkService.Watermark>
                 <TextBox.Resources>
-                <Style TargetType="{x:Type Border}">
-                    <Setter Property="CornerRadius" Value="25"/>
-                </Style>
-            </TextBox.Resources>
-        </TextBox>
+                    <Style TargetType="{x:Type Border}">
+                        <Setter Property="CornerRadius" Value="25"/>
+                    </Style>
+                </TextBox.Resources>
+            </TextBox>
         </AdornerDecorator>
         <Label Name="ErrorMail" Grid.Row="9"  Grid.Column="2" Grid.ColumnSpan="2"
                VerticalAlignment="Stretch" HorizontalAlignment="Stretch" 
@@ -289,7 +289,8 @@
                     <Setter Property="CornerRadius" Value="25"/>
                 </Style>
             </Button.Resources>
-            SELECCIONAR</Button>
+            SELECCIONAR
+        </Button>
 
         <Border Grid.Row="12"  Grid.Column="2" Grid.ColumnSpan="1" Margin="0,0,10,0"
                 Background="White" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
@@ -311,7 +312,7 @@
                     <Setter Property="CornerRadius" Value="25"/>
                 </Style>
             </Button.Resources>
-                INICIAR SIMULACION
+            INICIAR SIMULACION
         </Button>
         <!--<fa:ImageAwesome Grid.Column="2" Grid.ColumnSpan="2"
                          Opacity="0.6"
@@ -321,5 +322,5 @@
                          VerticalAlignment="Top" Grid.RowSpan="2" Grid.Row="1"
                          />-->
     </Grid>
-    
+
 </Page>

--- a/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
+++ b/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using LumbApp.Enums;
 using LumbApp.Models;
 using System;
-using System.Net.Mail;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;

--- a/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
+++ b/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
@@ -42,12 +42,12 @@ namespace LumbApp.GUI
             set { SetValue(DescriptionProperty, value); }
         }
 
-        private Regex regexApYN = new Regex("^[a-zA-ZñÑáéíóúÁÉÍÓÚ ]*$");
+        private readonly Regex regexApYN = new Regex("^[a-zA-ZñÑáéíóúÁÉÍÓÚ ]*$");
         //@ escapa toda la string que sigue, no necesitamos \\ para escribir una \
         //Este mail acepta letras, numeros, -, _ y . en el nombre
         //Acepta letras, numeros, _ y . en el dominio
         //Debe terminar con . y 2 o 3 letras
-        private Regex regexMail = new Regex(@"^[\w\.\-]+@[\w\.]+\.\w{2,3}$");
+        private readonly Regex regexMail = new Regex(@"^[\w\.\-]+@[\w\.]+\.\w{2,3}$");
         private bool dniValido;
         private bool nombreValido;
         private bool apellidoValido;

--- a/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
+++ b/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
@@ -24,8 +24,8 @@ namespace LumbApp.GUI
         public string Text { get { return GetValue(TextProperty) as string; } set { SetValue(TextProperty, value); } }
         public string Description { get { return GetValue(DescriptionProperty) as string; } set { SetValue(DescriptionProperty, value); } }
         
-        private Regex regexApYN = new Regex("^[a-zA-ZñÑ ]*$");
-        private Regex regexMail = new Regex(@"^([\w\.\-]+)@([\w\-]+)((\.(\w){2,3})+)$");
+        private readonly Regex regexApYN = new Regex("^[a-zA-ZñÑ ]*$");
+        private readonly Regex regexMail = new Regex(@"^([\w\.\-]+)@([\w\-]+)((\.(\w){2,3})+)$");
         private bool dniValido;
         private bool nombreValido;
         private bool apellidoValido;
@@ -46,11 +46,13 @@ namespace LumbApp.GUI
         /// <returns></returns>
         public DatosPracticante ProcesarDatos()
         {
-            DatosPracticante datosPracticante = new DatosPracticante();
-            datosPracticante.Nombre = Nombre.Text;
-            datosPracticante.Apellido = Apellido.Text;
-            datosPracticante.Dni = Int32.Parse( Dni.Text );
-            datosPracticante.FolderPath = FolderPath.Content.ToString();
+            DatosPracticante datosPracticante = new DatosPracticante
+            {
+                Nombre = Nombre.Text,
+                Apellido = Apellido.Text,
+                Dni = Int32.Parse(Dni.Text),
+                FolderPath = FolderPath.Content.ToString()
+            };
             return datosPracticante;
         }
 

--- a/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
+++ b/LumbApp/GUI/IngresoDatosPracticante.xaml.cs
@@ -75,7 +75,7 @@ namespace LumbApp.GUI
                 Dni = Int32.Parse(Dni.Text),
                 FolderPath = FolderPath.Content.ToString(),
                 Email = Mail.Text
-        };
+            };
             return datosPracticante;
         }
 

--- a/LumbApp/GUI/MainWindow.xaml.cs
+++ b/LumbApp/GUI/MainWindow.xaml.cs
@@ -15,7 +15,7 @@ namespace LumbApp.GUI
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
-        {      
+        {
             GUIController gui = new GUIController(this);
             gui.Inicializar();
         }

--- a/LumbApp/GUI/PasosPreparacion.xaml
+++ b/LumbApp/GUI/PasosPreparacion.xaml
@@ -147,7 +147,7 @@
                VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
                    Margin="0,10,0,0"
                FontSize="22" FontWeight="Regular" Foreground="#595959" Content="3. Segundo lavado de manos o &#10;  desinfección con alcohol gel">
-               </Label>
+            </Label>
         </Border>
         <Image Grid.Column="9" Grid.Row="1"
                 Grid.ColumnSpan="3"

--- a/LumbApp/GUI/PasosPreparacion.xaml.cs
+++ b/LumbApp/GUI/PasosPreparacion.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Media;
-using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;

--- a/LumbApp/GUI/PasosPreparacion.xaml.cs
+++ b/LumbApp/GUI/PasosPreparacion.xaml.cs
@@ -15,8 +15,8 @@ namespace LumbApp.GUI
     public partial class PasosPreparacion : Page
     {
         public GUIController _controller { get; set; }
-        private static string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\Preparacion\\";
-        private DispatcherTimer timer;
+        private static readonly string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\Preparacion\\";
+        private readonly DispatcherTimer timer;
         private int timeLeft { get; set; }
 
         public PasosPreparacion(GUIController gui)
@@ -24,8 +24,10 @@ namespace LumbApp.GUI
             InitializeComponent();
             _controller = gui;
             timeLeft = 30;
-            timer = new DispatcherTimer();
-            timer.Interval = TimeSpan.FromSeconds(1);
+            timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(1)
+            };
             timer.Tick += timer_Tick;
             timer.Start();
 

--- a/LumbApp/GUI/ResultadosSimulacion.xaml.cs
+++ b/LumbApp/GUI/ResultadosSimulacion.xaml.cs
@@ -27,10 +27,10 @@ namespace LumbApp.GUI
 
         public void MostrarResultados(Informe informe)
         {
-            NombrePracticante.Content = 
+            NombrePracticante.Content =
                 String.Format(
                     "{0}, {1}" + Environment.NewLine +
-                    "Path: {2}", informe.Apellido, informe.Nombre,informe.FolderPath);
+                    "Path: {2}", informe.Apellido, informe.Nombre, informe.FolderPath);
 
             DniPracticante.Content = "DNI: " + informe.Dni.ToString();
 
@@ -39,7 +39,7 @@ namespace LumbApp.GUI
 
             foreach (DictionaryEntry dato in informe.DatosPractica)
             {
-                if(i <= halfPoint)
+                if (i <= halfPoint)
                 {
                     ReporteItemTitulo1.Content += String.Format("{0}" + Environment.NewLine, dato.Key);
                     ReporteItemValor1.Content += String.Format("{0}" + Environment.NewLine, dato.Value);

--- a/LumbApp/GUI/SimulacionModoEvaluacion.cs
+++ b/LumbApp/GUI/SimulacionModoEvaluacion.cs
@@ -1,15 +1,7 @@
-﻿using LumbApp.Expertos.ExpertoSI;
-using LumbApp.Expertos.ExpertoSI.Utils;
-using LumbApp.Expertos.ExpertoZE;
-using System;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Media;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Threading;
 
 namespace LumbApp.GUI
 {

--- a/LumbApp/GUI/SimulacionModoEvaluacion.cs
+++ b/LumbApp/GUI/SimulacionModoEvaluacion.cs
@@ -23,7 +23,7 @@ namespace LumbApp.GUI
         //Path General de Carpeta de Imagenes
         private static string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\";
 
-       
+
         public SimulacionModoEvaluacion(GUIController gui)
         {
             InitializeComponent();

--- a/LumbApp/GUI/SimulacionModoEvaluacion.cs
+++ b/LumbApp/GUI/SimulacionModoEvaluacion.cs
@@ -21,7 +21,7 @@ namespace LumbApp.GUI
         public GUIController _controller { get; set; }
 
         //Path General de Carpeta de Imagenes
-        private static string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\";
+        private static readonly string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\";
 
 
         public SimulacionModoEvaluacion(GUIController gui)

--- a/LumbApp/GUI/SimulacionModoEvaluacion.xaml
+++ b/LumbApp/GUI/SimulacionModoEvaluacion.xaml
@@ -68,7 +68,7 @@
                 Width="600"
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch" 
                 CornerRadius="40"/>
-        
+
         <!--Spinner-->
         <fa:ImageAwesome Name="SpinerIcon" 
                          Grid.Column="0" Grid.Row="1" 

--- a/LumbApp/GUI/SimulacionModoGuiado.cs
+++ b/LumbApp/GUI/SimulacionModoGuiado.cs
@@ -26,19 +26,19 @@ namespace LumbApp.GUI
         int timeLeft { get; set; }
 
         //Path General de Carpeta de Imagenes
-        private static string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\";
+        private static readonly string _imagesFolderPath = Directory.GetParent(Environment.CurrentDirectory).Parent.FullName + "\\GUI\\Imagenes\\";
 
         //Paths de manos
-        private static string _manoPerdidaSubPath = "Manos\\NoTraqueando\\";
-        private static string _manoTrackeadaSubPath = "Manos\\Traqueando\\";
-        private static string _manoFueraInicialPath = "mano-fuera-inicial.png";
-        private static string _manoFueraPath = "mano-fuera.png";
-        private static string _manoDentroPath = "mano-dentro.png";
-        private static string _manoContaminadaPath = "mano-contaminadaX.png";
+        private static readonly string _manoPerdidaSubPath = "Manos\\NoTraqueando\\";
+        private static readonly string _manoTrackeadaSubPath = "Manos\\Traqueando\\";
+        private static readonly string _manoFueraInicialPath = "mano-fuera-inicial.png";
+        private static readonly string _manoFueraPath = "mano-fuera.png";
+        private static readonly string _manoDentroPath = "mano-dentro.png";
+        private static readonly string _manoContaminadaPath = "mano-contaminadaX.png";
 
         //Paths de capas
-        private static string _capasFrontPath = _imagesFolderPath + "Capas\\Frente\\";
-        private static string _capasSidePath = _imagesFolderPath + "Capas\\Costado\\";
+        private static readonly string _capasFrontPath = _imagesFolderPath + "Capas\\Frente\\";
+        private static readonly string _capasSidePath = _imagesFolderPath + "Capas\\Costado\\";
 
         //Colores
         private static Brush[] coloresContaminando { get; set; }

--- a/LumbApp/GUI/SimulacionModoGuiado.cs
+++ b/LumbApp/GUI/SimulacionModoGuiado.cs
@@ -61,20 +61,20 @@ namespace LumbApp.GUI
 
             //inicializo imagenes de capas
             PielSideImage.Source = new BitmapImage(new Uri(_imagesFolderPath + "Capas\\Costado\\piel_OFF.png", UriKind.Absolute));
-            SideBaseImage.Source = new BitmapImage( new Uri(_imagesFolderPath + "Capas\\Costado\\base.png", UriKind.Absolute));
+            SideBaseImage.Source = new BitmapImage(new Uri(_imagesFolderPath + "Capas\\Costado\\base.png", UriKind.Absolute));
             FrontBaseImage.Source = new BitmapImage(new Uri(_imagesFolderPath + "Capas\\Frente\\base.png", UriKind.Absolute));
 
             //inicializo colores
             brushConverter = new BrushConverter();
             white = (Brush)brushConverter.ConvertFrom("#ffffff");
             black = (Brush)brushConverter.ConvertFrom("#323232");
-            green= (Brush)brushConverter.ConvertFrom("#a7f192");
+            green = (Brush)brushConverter.ConvertFrom("#a7f192");
             darkred = (Brush)brushConverter.ConvertFrom("#bc100c");
             string[] colores = { "#dcf192", "#f1ef92", "#f1d792", "#f1b392", "#f19292", "#f3817e", "#ff6161" };
             coloresContaminando = new Brush[colores.Count()];
-            for(int i =0; i< colores.Count() ;i++)
+            for (int i = 0; i < colores.Count(); i++)
             {
-                coloresContaminando[i]= (Brush)brushConverter.ConvertFrom(colores[i]);
+                coloresContaminando[i] = (Brush)brushConverter.ConvertFrom(colores[i]);
             }
 
             //inicializo los labels de las manos
@@ -94,7 +94,7 @@ namespace LumbApp.GUI
             ManosImageConfig config = GetNuevaConfiguracionImagenMano(e.ManoIzquierda.Track, e.ManoIzquierda.Estado, e.ManoIzquierda.VecesContamino);
 
             ImageSource nuevaImagen = new BitmapImage(
-               new Uri(_imagesFolderPath +config.TrackingPath +config.EstadoPath, UriKind.Absolute));
+               new Uri(_imagesFolderPath + config.TrackingPath + config.EstadoPath, UriKind.Absolute));
             ManoIzquierda.Source = nuevaImagen;
             ManoIzqLabel.Background = config.LabelColor;
             ManoIzqLabel.Foreground = config.FontColor;
@@ -111,7 +111,7 @@ namespace LumbApp.GUI
             ManoDerLabel.Content = config.Texto;
 
             //Alerta sonido
-            if(e.ContaminadoAhora)
+            if (e.ContaminadoAhora)
                 SystemSounds.Exclamation.Play();
 
             SalidasZELabel.Content = String.Format("Se contamino la Zona Estéril {0} Veces", e.VecesContaminado);
@@ -149,7 +149,7 @@ namespace LumbApp.GUI
                     {
                         int nroContaminacion = (nroIngreso > 7 ? 7 : nroIngreso);
                         config.EstadoPath = _manoContaminadaPath.Replace("X", nroContaminacion.ToString()); ;
-                        config.LabelColor = coloresContaminando[nroContaminacion-1];
+                        config.LabelColor = coloresContaminando[nroContaminacion - 1];
                         config.FontColor = black;
                         config.Texto = "Contaminando";
                         break;
@@ -173,12 +173,12 @@ namespace LumbApp.GUI
             //ATRAVIESA LA PIEL
             if (e.TejidoAdiposo.Estado == Capa.Estados.Atravesando || e.TejidoAdiposo.Estado == Capa.Estados.AtravesandoNuevamente)
             {
-                PielSideImage.Source = new BitmapImage(new Uri( _capasSidePath + "piel_ON.png", UriKind.Absolute));
+                PielSideImage.Source = new BitmapImage(new Uri(_capasSidePath + "piel_ON.png", UriKind.Absolute));
                 CapaActualLabel.Content = "TEJIDO ADIPOSO";
             }
             else
             {
-                PielSideImage.Source = new BitmapImage(new Uri( _capasSidePath + "piel_OFF.png", UriKind.Absolute));
+                PielSideImage.Source = new BitmapImage(new Uri(_capasSidePath + "piel_OFF.png", UriKind.Absolute));
                 CapaActualLabel.Content = "NINGUNA";
             }
 
@@ -187,7 +187,7 @@ namespace LumbApp.GUI
             {
                 CapaActualLabel.Content = "LIGAMENTO INTERESPINOSO";
                 RozandoLabel.Content = "L2";
-                L2SideImage.Source = new BitmapImage(new Uri(_capasSidePath + "L2 adelante.png", UriKind.Absolute)); 
+                L2SideImage.Source = new BitmapImage(new Uri(_capasSidePath + "L2 adelante.png", UriKind.Absolute));
                 L2SFrontImage.Source = new BitmapImage(new Uri(_capasFrontPath + "L2 adelante.png", UriKind.Absolute));
             }
 
@@ -208,7 +208,7 @@ namespace LumbApp.GUI
                     L3SideImage.Source = new BitmapImage(new Uri(_capasSidePath + "L3 arriba.png", UriKind.Absolute));
                 }
             }
-            else 
+            else
             {
                 L3FrontImage.Source = null;
                 L3SideImage.Source = null;
@@ -274,17 +274,17 @@ namespace LumbApp.GUI
 
         private void MostrarAlertas(CambioSIEventArgs e)
         {
-            if((e.L3RozandoAhora && e.L3.Sector == VertebraL3.Sectores.Arriba) ||
+            if ((e.L3RozandoAhora && e.L3.Sector == VertebraL3.Sectores.Arriba) ||
                (e.L4RozandoAhora && e.L4.Sector == VertebraL4.Sectores.Abajo) ||
                 e.L2RozandoAhora || e.L5RozandoAhora)
             {
                 AlertaLabel.Content = "Hey!! mira donde estas pinchando!";
-                AlertaLabelBorder.Opacity=0.7;
+                AlertaLabelBorder.Opacity = 0.7;
                 SystemSounds.Exclamation.Play();
                 StartAlertTimer();
             }
-            else if (e.L4RozandoAhora && 
-                e.L4.Sector != VertebraL4.Sectores.Abajo && 
+            else if (e.L4RozandoAhora &&
+                e.L4.Sector != VertebraL4.Sectores.Abajo &&
                 e.L4.Sector != VertebraL4.Sectores.ArribaCentro)
             {
                 AlertaLabel.Content = "Casi casi!";
@@ -334,7 +334,7 @@ namespace LumbApp.GUI
 
     }
 
-     public class ManosImageConfig
+    public class ManosImageConfig
     {
         public Brush LabelColor { get; set; }
         public Brush FontColor { get; set; }

--- a/LumbApp/GUI/SimulacionModoGuiado.xaml
+++ b/LumbApp/GUI/SimulacionModoGuiado.xaml
@@ -89,9 +89,9 @@
                VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
                Margin="20,0,0,10"
                FontSize="22" FontWeight="DemiBold" Foreground="#595959"></Label>
-        
+
         <!--Imagenes Capas Side-->
-        
+
         <Image  Name="PielSideImage"
                 Grid.Row="3" Grid.Column="0" 
                 Grid.RowSpan="3" 
@@ -175,7 +175,7 @@
  
                VerticalAlignment="Stretch" HorizontalAlignment="Center" 
                 Margin="50,10,0,20"/>
-        
+
         <!--Etiquetas Manos-->
         <Label Grid.Row="1" Grid.Column="2" Name="ManoIzqLabel"
                VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
@@ -193,7 +193,7 @@
                HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
             Derecha
         </Label>
-        
+
         <!--Manos Images-->
         <Image Grid.Row="2" Grid.Column="3" Grid.RowSpan="2" 
                Name="ManoIzquierda" VerticalAlignment="Center"
@@ -206,7 +206,7 @@
                Name="ManoDerecha" 
                VerticalAlignment="Center" HorizontalAlignment="Stretch" 
                Margin="0,10,10,10"/>
-        
+
         <!--Rozando Label -->
         <Border Grid.Row="1" Grid.Column="1" Grid.RowSpan="2"
                 Background="White" Opacity="0.7"
@@ -223,7 +223,7 @@
                VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
                Margin="0,0,0,10"
                FontSize="22" FontWeight="DemiBold" Foreground="#595959"></Label>
-        
+
         <!--Label de alertas-->
         <Border Name="AlertaLabelBorder"
                 Grid.Row="0" Grid.Column="0" 
@@ -236,7 +236,7 @@
                VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
                FontSize="24" FontWeight="DemiBold" Foreground="White"></Label>
         </Border>
-        
+
         <!--Label de Salidas de ZE-->
         <Border Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2"
                 Background="White" Opacity="0.7"
@@ -247,7 +247,7 @@
                VerticalContentAlignment="Center" HorizontalContentAlignment="Center"
                FontSize="22" FontWeight="DemiBold" Foreground="#323232"></Label>
         </Border>
-        
+
         <!--Label de Capas Atravesadas-->
         <Label
                Grid.Row="4" Grid.Column="2"

--- a/LumbApp/GUI/SimulacionModoGuiado.xaml
+++ b/LumbApp/GUI/SimulacionModoGuiado.xaml
@@ -137,8 +137,7 @@
 
         <Image Grid.Row="3" Grid.Column="1" 
                Grid.RowSpan="3" Name="FrontBaseImage"
-               VerticalAlignment="Stretch" HorizontalAlignment="Center" 
-               Source="C:\Users\Lara\source\repos\lumbapp\LumbApp\GUI\Imagenes\Capas\Frente\base.png"
+               VerticalAlignment="Stretch" HorizontalAlignment="Center"
                Margin="50,10,0,20" />
 
         <Image  Name="DuramadreFrontImage"

--- a/LumbApp/GUI/WatermarkAdorner.cs
+++ b/LumbApp/GUI/WatermarkAdorner.cs
@@ -10,109 +10,109 @@ namespace LumbApp.GUI
     /// Adorner for the watermark
     /// </summary>
     internal class WatermarkAdorner : Adorner
-{
-    #region Private Fields
-
-    /// <summary>
-    /// <see cref="ContentPresenter"/> that holds the watermark
-    /// </summary>
-    private readonly ContentPresenter contentPresenter;
-
-    #endregion
-
-    #region Constructor
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="WatermarkAdorner"/> class
-    /// </summary>
-    /// <param name="adornedElement"><see cref="UIElement"/> to be adorned</param>
-    /// <param name="watermark">The watermark</param>
-    public WatermarkAdorner(UIElement adornedElement, object watermark) :
-       base(adornedElement)
     {
-        this.IsHitTestVisible = false;
+        #region Private Fields
 
-        this.contentPresenter = new ContentPresenter();
-        this.contentPresenter.Content = watermark;
-        this.contentPresenter.Opacity = 0.5;
-        this.contentPresenter.Margin = new Thickness(Control.Margin.Left + Control.Padding.Left, Control.Margin.Top + Control.Padding.Top, 0, 0);
-        this.VerticalAlignment = VerticalAlignment.Center;
-        this.contentPresenter.VerticalAlignment = VerticalAlignment.Center;
+        /// <summary>
+        /// <see cref="ContentPresenter"/> that holds the watermark
+        /// </summary>
+        private readonly ContentPresenter contentPresenter;
 
-        if (this.Control is ItemsControl && !(this.Control is ComboBox))
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WatermarkAdorner"/> class
+        /// </summary>
+        /// <param name="adornedElement"><see cref="UIElement"/> to be adorned</param>
+        /// <param name="watermark">The watermark</param>
+        public WatermarkAdorner(UIElement adornedElement, object watermark) :
+           base(adornedElement)
         {
+            this.IsHitTestVisible = false;
+
+            this.contentPresenter = new ContentPresenter();
+            this.contentPresenter.Content = watermark;
+            this.contentPresenter.Opacity = 0.5;
+            this.contentPresenter.Margin = new Thickness(Control.Margin.Left + Control.Padding.Left, Control.Margin.Top + Control.Padding.Top, 0, 0);
+            this.VerticalAlignment = VerticalAlignment.Center;
             this.contentPresenter.VerticalAlignment = VerticalAlignment.Center;
-            this.contentPresenter.HorizontalAlignment = HorizontalAlignment.Center;
+
+            if (this.Control is ItemsControl && !(this.Control is ComboBox))
+            {
+                this.contentPresenter.VerticalAlignment = VerticalAlignment.Center;
+                this.contentPresenter.HorizontalAlignment = HorizontalAlignment.Center;
+            }
+
+            // Hide the control adorner when the adorned element is hidden
+            Binding binding = new Binding("IsVisible");
+            binding.Source = adornedElement;
+            binding.Converter = new BooleanToVisibilityConverter();
+            this.SetBinding(VisibilityProperty, binding);
         }
 
-        // Hide the control adorner when the adorned element is hidden
-        Binding binding = new Binding("IsVisible");
-        binding.Source = adornedElement;
-        binding.Converter = new BooleanToVisibilityConverter();
-        this.SetBinding(VisibilityProperty, binding);
+        #endregion
+
+        #region Protected Properties
+
+        /// <summary>
+        /// Gets the number of children for the <see cref="ContainerVisual"/>.
+        /// </summary>
+        protected override int VisualChildrenCount
+        {
+            get { return 1; }
+        }
+
+        #endregion
+
+        #region Private Properties
+
+        /// <summary>
+        /// Gets the control that is being adorned
+        /// </summary>
+        private Control Control
+        {
+            get { return (Control)this.AdornedElement; }
+        }
+
+        #endregion
+
+        #region Protected Overrides
+
+        /// <summary>
+        /// Returns a specified child <see cref="Visual"/> for the parent <see cref="ContainerVisual"/>.
+        /// </summary>
+        /// <param name="index">A 32-bit signed integer that represents the index value of the child <see cref="Visual"/>. The value of index must be between 0 and <see cref="VisualChildrenCount"/> - 1.</param>
+        /// <returns>The child <see cref="Visual"/>.</returns>
+        protected override Visual GetVisualChild(int index)
+        {
+            return this.contentPresenter;
+        }
+
+        /// <summary>
+        /// Implements any custom measuring behavior for the adorner.
+        /// </summary>
+        /// <param name="constraint">A size to constrain the adorner to.</param>
+        /// <returns>A <see cref="Size"/> object representing the amount of layout space needed by the adorner.</returns>
+        protected override Size MeasureOverride(Size constraint)
+        {
+            // Here's the secret to getting the adorner to cover the whole control
+            this.contentPresenter.Measure(Control.RenderSize);
+            return Control.RenderSize;
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, positions child elements and determines a size for a <see cref="FrameworkElement"/> derived class. 
+        /// </summary>
+        /// <param name="finalSize">The final area within the parent that this element should use to arrange itself and its children.</param>
+        /// <returns>The actual size used.</returns>
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            this.contentPresenter.Arrange(new Rect(finalSize));
+            return finalSize;
+        }
+
+        #endregion
     }
-
-    #endregion
-
-    #region Protected Properties
-
-    /// <summary>
-    /// Gets the number of children for the <see cref="ContainerVisual"/>.
-    /// </summary>
-    protected override int VisualChildrenCount
-    {
-        get { return 1; }
-    }
-
-    #endregion
-
-    #region Private Properties
-
-    /// <summary>
-    /// Gets the control that is being adorned
-    /// </summary>
-    private Control Control
-    {
-        get { return (Control)this.AdornedElement; }
-    }
-
-    #endregion
-
-    #region Protected Overrides
-
-    /// <summary>
-    /// Returns a specified child <see cref="Visual"/> for the parent <see cref="ContainerVisual"/>.
-    /// </summary>
-    /// <param name="index">A 32-bit signed integer that represents the index value of the child <see cref="Visual"/>. The value of index must be between 0 and <see cref="VisualChildrenCount"/> - 1.</param>
-    /// <returns>The child <see cref="Visual"/>.</returns>
-    protected override Visual GetVisualChild(int index)
-    {
-        return this.contentPresenter;
-    }
-
-    /// <summary>
-    /// Implements any custom measuring behavior for the adorner.
-    /// </summary>
-    /// <param name="constraint">A size to constrain the adorner to.</param>
-    /// <returns>A <see cref="Size"/> object representing the amount of layout space needed by the adorner.</returns>
-    protected override Size MeasureOverride(Size constraint)
-    {
-        // Here's the secret to getting the adorner to cover the whole control
-        this.contentPresenter.Measure(Control.RenderSize);
-        return Control.RenderSize;
-    }
-
-    /// <summary>
-    /// When overridden in a derived class, positions child elements and determines a size for a <see cref="FrameworkElement"/> derived class. 
-    /// </summary>
-    /// <param name="finalSize">The final area within the parent that this element should use to arrange itself and its children.</param>
-    /// <returns>The actual size used.</returns>
-    protected override Size ArrangeOverride(Size finalSize)
-    {
-        this.contentPresenter.Arrange(new Rect(finalSize));
-        return finalSize;
-    }
-
-    #endregion
-}
 }

--- a/LumbApp/GUI/WatermarkAdorner.cs
+++ b/LumbApp/GUI/WatermarkAdorner.cs
@@ -32,10 +32,12 @@ namespace LumbApp.GUI
         {
             this.IsHitTestVisible = false;
 
-            this.contentPresenter = new ContentPresenter();
-            this.contentPresenter.Content = watermark;
-            this.contentPresenter.Opacity = 0.5;
-            this.contentPresenter.Margin = new Thickness(Control.Margin.Left + Control.Padding.Left, Control.Margin.Top + Control.Padding.Top, 0, 0);
+            this.contentPresenter = new ContentPresenter
+            {
+                Content = watermark,
+                Opacity = 0.5,
+                Margin = new Thickness(Control.Margin.Left + Control.Padding.Left, Control.Margin.Top + Control.Padding.Top, 0, 0)
+            };
             this.VerticalAlignment = VerticalAlignment.Center;
             this.contentPresenter.VerticalAlignment = VerticalAlignment.Center;
 

--- a/LumbApp/GUI/WatermarkService.cs
+++ b/LumbApp/GUI/WatermarkService.cs
@@ -12,125 +12,91 @@ namespace LumbApp.GUI
     /// Class that provides the Watermark attached property
     /// </summary>
     public static class WatermarkService
-{
-    /// <summary>
-    /// Watermark Attached Dependency Property
-    /// </summary>
-    public static readonly DependencyProperty WatermarkProperty = DependencyProperty.RegisterAttached(
-       "Watermark",
-       typeof(object),
-       typeof(WatermarkService),
-       new FrameworkPropertyMetadata((object)null, new PropertyChangedCallback(OnWatermarkChanged)));
-
-    #region Private Fields
-
-    /// <summary>
-    /// Dictionary of ItemsControls
-    /// </summary>
-    private static readonly Dictionary<object, ItemsControl> itemsControls = new Dictionary<object, ItemsControl>();
-
-    #endregion
-
-    /// <summary>
-    /// Gets the Watermark property.  This dependency property indicates the watermark for the control.
-    /// </summary>
-    /// <param name="d"><see cref="DependencyObject"/> to get the property from</param>
-    /// <returns>The value of the Watermark property</returns>
-    public static object GetWatermark(DependencyObject d)
     {
-        return (object)d.GetValue(WatermarkProperty);
-    }
+        /// <summary>
+        /// Watermark Attached Dependency Property
+        /// </summary>
+        public static readonly DependencyProperty WatermarkProperty = DependencyProperty.RegisterAttached(
+           "Watermark",
+           typeof(object),
+           typeof(WatermarkService),
+           new FrameworkPropertyMetadata((object)null, new PropertyChangedCallback(OnWatermarkChanged)));
 
-    /// <summary>
-    /// Sets the Watermark property.  This dependency property indicates the watermark for the control.
-    /// </summary>
-    /// <param name="d"><see cref="DependencyObject"/> to set the property on</param>
-    /// <param name="value">value of the property</param>
-    public static void SetWatermark(DependencyObject d, object value)
-    {
-        d.SetValue(WatermarkProperty, value);
-    }
+        #region Private Fields
 
-    /// <summary>
-    /// Handles changes to the Watermark property.
-    /// </summary>
-    /// <param name="d"><see cref="DependencyObject"/> that fired the event</param>
-    /// <param name="e">A <see cref="DependencyPropertyChangedEventArgs"/> that contains the event data.</param>
-    private static void OnWatermarkChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        Control control = (Control)d;
-        control.Loaded += Control_Loaded;
+        /// <summary>
+        /// Dictionary of ItemsControls
+        /// </summary>
+        private static readonly Dictionary<object, ItemsControl> itemsControls = new Dictionary<object, ItemsControl>();
 
-        if (d is ComboBox)
+        #endregion
+
+        /// <summary>
+        /// Gets the Watermark property.  This dependency property indicates the watermark for the control.
+        /// </summary>
+        /// <param name="d"><see cref="DependencyObject"/> to get the property from</param>
+        /// <returns>The value of the Watermark property</returns>
+        public static object GetWatermark(DependencyObject d)
         {
-            control.GotKeyboardFocus += Control_GotKeyboardFocus;
-            control.LostKeyboardFocus += Control_Loaded;
-        }
-        else if (d is TextBox)
-        {
-            control.GotKeyboardFocus += Control_GotKeyboardFocus;
-            control.LostKeyboardFocus += Control_Loaded;
-            ((TextBox)control).TextChanged += Control_GotKeyboardFocus;
+            return (object)d.GetValue(WatermarkProperty);
         }
 
-        if (d is ItemsControl && !(d is ComboBox))
+        /// <summary>
+        /// Sets the Watermark property.  This dependency property indicates the watermark for the control.
+        /// </summary>
+        /// <param name="d"><see cref="DependencyObject"/> to set the property on</param>
+        /// <param name="value">value of the property</param>
+        public static void SetWatermark(DependencyObject d, object value)
         {
-            ItemsControl i = (ItemsControl)d;
-
-            // for Items property  
-            i.ItemContainerGenerator.ItemsChanged += ItemsChanged;
-            itemsControls.Add(i.ItemContainerGenerator, i);
-
-            // for ItemsSource property  
-            DependencyPropertyDescriptor prop = DependencyPropertyDescriptor.FromProperty(ItemsControl.ItemsSourceProperty, i.GetType());
-            prop.AddValueChanged(i, ItemsSourceChanged);
+            d.SetValue(WatermarkProperty, value);
         }
-    }
 
-    #region Event Handlers
-
-    /// <summary>
-    /// Handle the GotFocus event on the control
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">A <see cref="RoutedEventArgs"/> that contains the event data.</param>
-    private static void Control_GotKeyboardFocus(object sender, RoutedEventArgs e)
-    {
-        Control c = (Control)sender;
-        if (ShouldShowWatermark(c))
+        /// <summary>
+        /// Handles changes to the Watermark property.
+        /// </summary>
+        /// <param name="d"><see cref="DependencyObject"/> that fired the event</param>
+        /// <param name="e">A <see cref="DependencyPropertyChangedEventArgs"/> that contains the event data.</param>
+        private static void OnWatermarkChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ShowWatermark(c);
+            Control control = (Control)d;
+            control.Loaded += Control_Loaded;
+
+            if (d is ComboBox)
+            {
+                control.GotKeyboardFocus += Control_GotKeyboardFocus;
+                control.LostKeyboardFocus += Control_Loaded;
+            }
+            else if (d is TextBox)
+            {
+                control.GotKeyboardFocus += Control_GotKeyboardFocus;
+                control.LostKeyboardFocus += Control_Loaded;
+                ((TextBox)control).TextChanged += Control_GotKeyboardFocus;
+            }
+
+            if (d is ItemsControl && !(d is ComboBox))
+            {
+                ItemsControl i = (ItemsControl)d;
+
+                // for Items property  
+                i.ItemContainerGenerator.ItemsChanged += ItemsChanged;
+                itemsControls.Add(i.ItemContainerGenerator, i);
+
+                // for ItemsSource property  
+                DependencyPropertyDescriptor prop = DependencyPropertyDescriptor.FromProperty(ItemsControl.ItemsSourceProperty, i.GetType());
+                prop.AddValueChanged(i, ItemsSourceChanged);
+            }
         }
-        else
-        {
-            RemoveWatermark(c);
-        }
-    }
 
-    /// <summary>
-    /// Handle the Loaded and LostFocus event on the control
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">A <see cref="RoutedEventArgs"/> that contains the event data.</param>
-    private static void Control_Loaded(object sender, RoutedEventArgs e)
-    {
-        Control control = (Control)sender;
-        if (ShouldShowWatermark(control))
-        {
-            ShowWatermark(control);
-        }
-    }
+        #region Event Handlers
 
-    /// <summary>
-    /// Event handler for the items source changed event
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">A <see cref="EventArgs"/> that contains the event data.</param>
-    private static void ItemsSourceChanged(object sender, EventArgs e)
-    {
-        ItemsControl c = (ItemsControl)sender;
-        if (c.ItemsSource != null)
+        /// <summary>
+        /// Handle the GotFocus event on the control
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">A <see cref="RoutedEventArgs"/> that contains the event data.</param>
+        private static void Control_GotKeyboardFocus(object sender, RoutedEventArgs e)
         {
+            Control c = (Control)sender;
             if (ShouldShowWatermark(c))
             {
                 ShowWatermark(c);
@@ -140,106 +106,140 @@ namespace LumbApp.GUI
                 RemoveWatermark(c);
             }
         }
-        else
-        {
-            ShowWatermark(c);
-        }
-    }
 
-    /// <summary>
-    /// Event handler for the items changed event
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">A <see cref="ItemsChangedEventArgs"/> that contains the event data.</param>
-    private static void ItemsChanged(object sender, ItemsChangedEventArgs e)
-    {
-        ItemsControl control;
-        if (itemsControls.TryGetValue(sender, out control))
+        /// <summary>
+        /// Handle the Loaded and LostFocus event on the control
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">A <see cref="RoutedEventArgs"/> that contains the event data.</param>
+        private static void Control_Loaded(object sender, RoutedEventArgs e)
         {
+            Control control = (Control)sender;
             if (ShouldShowWatermark(control))
             {
                 ShowWatermark(control);
             }
+        }
+
+        /// <summary>
+        /// Event handler for the items source changed event
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">A <see cref="EventArgs"/> that contains the event data.</param>
+        private static void ItemsSourceChanged(object sender, EventArgs e)
+        {
+            ItemsControl c = (ItemsControl)sender;
+            if (c.ItemsSource != null)
+            {
+                if (ShouldShowWatermark(c))
+                {
+                    ShowWatermark(c);
+                }
+                else
+                {
+                    RemoveWatermark(c);
+                }
+            }
             else
             {
-                RemoveWatermark(control);
+                ShowWatermark(c);
             }
         }
-    }
 
-    #endregion
-
-    #region Helper Methods
-
-    /// <summary>
-    /// Remove the watermark from the specified element
-    /// </summary>
-    /// <param name="control">Element to remove the watermark from</param>
-    private static void RemoveWatermark(UIElement control)
-    {
-        AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
-
-        // layer could be null if control is no longer in the visual tree
-        if (layer != null)
+        /// <summary>
+        /// Event handler for the items changed event
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">A <see cref="ItemsChangedEventArgs"/> that contains the event data.</param>
+        private static void ItemsChanged(object sender, ItemsChangedEventArgs e)
         {
-            Adorner[] adorners = layer.GetAdorners(control);
-            if (adorners == null)
+            ItemsControl control;
+            if (itemsControls.TryGetValue(sender, out control))
             {
-                return;
-            }
-
-            foreach (Adorner adorner in adorners)
-            {
-                if (adorner is WatermarkAdorner)
+                if (ShouldShowWatermark(control))
                 {
-                    adorner.Visibility = Visibility.Hidden;
-                    layer.Remove(adorner);
+                    ShowWatermark(control);
+                }
+                else
+                {
+                    RemoveWatermark(control);
                 }
             }
         }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Remove the watermark from the specified element
+        /// </summary>
+        /// <param name="control">Element to remove the watermark from</param>
+        private static void RemoveWatermark(UIElement control)
+        {
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
+
+            // layer could be null if control is no longer in the visual tree
+            if (layer != null)
+            {
+                Adorner[] adorners = layer.GetAdorners(control);
+                if (adorners == null)
+                {
+                    return;
+                }
+
+                foreach (Adorner adorner in adorners)
+                {
+                    if (adorner is WatermarkAdorner)
+                    {
+                        adorner.Visibility = Visibility.Hidden;
+                        layer.Remove(adorner);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Show the watermark on the specified control
+        /// </summary>
+        /// <param name="control">Control to show the watermark on</param>
+        private static void ShowWatermark(Control control)
+        {
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
+
+            // layer could be null if control is no longer in the visual tree
+            if (layer != null)
+            {
+                layer.Add(new WatermarkAdorner(control, GetWatermark(control)));
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether or not the watermark should be shown on the specified control
+        /// </summary>
+        /// <param name="c"><see cref="Control"/> to test</param>
+        /// <returns>true if the watermark should be shown; false otherwise</returns>
+        private static bool ShouldShowWatermark(Control c)
+        {
+            if (c is ComboBox)
+            {
+                return (c as ComboBox).Text == string.Empty;
+            }
+            else if (c is TextBoxBase)
+            {
+                return (c as TextBox).Text == string.Empty;
+            }
+            else if (c is ItemsControl)
+            {
+                return (c as ItemsControl).Items.Count == 0;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        #endregion
     }
-
-    /// <summary>
-    /// Show the watermark on the specified control
-    /// </summary>
-    /// <param name="control">Control to show the watermark on</param>
-    private static void ShowWatermark(Control control)
-    {
-        AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
-
-        // layer could be null if control is no longer in the visual tree
-        if (layer != null)
-        {
-            layer.Add(new WatermarkAdorner(control, GetWatermark(control)));
-        }
-    }
-
-    /// <summary>
-    /// Indicates whether or not the watermark should be shown on the specified control
-    /// </summary>
-    /// <param name="c"><see cref="Control"/> to test</param>
-    /// <returns>true if the watermark should be shown; false otherwise</returns>
-    private static bool ShouldShowWatermark(Control c)
-    {
-        if (c is ComboBox)
-        {
-            return (c as ComboBox).Text == string.Empty;
-        }
-        else if (c is TextBoxBase)
-        {
-            return (c as TextBox).Text == string.Empty;
-        }
-        else if (c is ItemsControl)
-        {
-            return (c as ItemsControl).Items.Count == 0;
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    #endregion
-}
 
 }

--- a/LumbApp/GUI/WatermarkService.cs
+++ b/LumbApp/GUI/WatermarkService.cs
@@ -73,9 +73,9 @@ namespace LumbApp.GUI
                 ((TextBox)control).TextChanged += Control_GotKeyboardFocus;
             }
 
-            if (d is ItemsControl && !(d is ComboBox))
+            if (d is ItemsControl control1 && !(d is ComboBox))
             {
-                ItemsControl i = (ItemsControl)d;
+                ItemsControl i = control1;
 
                 // for Items property  
                 i.ItemContainerGenerator.ItemsChanged += ItemsChanged;

--- a/LumbApp/LumbApp.csproj
+++ b/LumbApp/LumbApp.csproj
@@ -77,7 +77,7 @@
     <Reference Include="Accord.Video.FFMPEG, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=x86">
       <HintPath>packages\Accord.Video.FFMPEG.3.8.0\lib\net462\Accord.Video.FFMPEG.dll</HintPath>
     </Reference>
-	<Reference Include="BouncyCastle.Crypto, Version=1.8.6.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.6.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
       <HintPath>packages\BouncyCastle.1.8.6.1\lib\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -236,7 +236,6 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Conectores\ConectorSI\conector.exe" />
-    <Content Include="FinalFeedbacker\init.txt" />
     <Content Include="GUI\Imagenes\Capas\Costado\base.png" />
     <Content Include="GUI\Imagenes\Capas\Costado\duramadre.png" />
     <Content Include="GUI\Imagenes\Capas\Costado\L2 adelante.png" />

--- a/LumbApp/Models/DatosPracticante.cs
+++ b/LumbApp/Models/DatosPracticante.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace LumbApp.Models
+﻿namespace LumbApp.Models
 {
     public class DatosPracticante
     {

--- a/LumbApp/Models/Informe.cs
+++ b/LumbApp/Models/Informe.cs
@@ -1,11 +1,7 @@
 ﻿using LumbApp.Expertos.ExpertoSI;
 using LumbApp.Expertos.ExpertoZE;
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LumbApp.Models
 {

--- a/LumbApp/Models/Informe.cs
+++ b/LumbApp/Models/Informe.cs
@@ -33,26 +33,29 @@ namespace LumbApp.Models
 
         private void ArmarDiccionarioOrdenado(InformeSI informeSI, InformeZE informeZE, TimeSpan tiempoTotalDeEjecucion)
         {
-            DatosPractica = new OrderedDictionary();
-
-
-            DatosPractica.Add("Contaminaciones Zona", Convert.ToString(informeZE.Zona));
-            DatosPractica.Add("Contaminaciones Mano Izquierda", Convert.ToString(informeZE.ManoIzquierda));
-            DatosPractica.Add("Contaminaciones Mano Derecha", Convert.ToString(informeZE.ManoDerecha));
-            DatosPractica.Add("Punciones Tejido Adiposo", Convert.ToString(informeSI.TejidoAdiposo));
-            DatosPractica.Add("Roces L2", Convert.ToString(informeSI.L2));
-            DatosPractica.Add("Roces L3 Arriba", Convert.ToString(informeSI.L3Arriba));
-            DatosPractica.Add("Roces L3 Abajo", Convert.ToString(informeSI.L3Abajo));
-            DatosPractica.Add("Roces L4 Arriba Izquierda", Convert.ToString(informeSI.L4ArribaIzquierda));
-            DatosPractica.Add("Roces L4 Arriba Derecha", Convert.ToString(informeSI.L4ArribaDerecha));
-            DatosPractica.Add("Roces L4 Arriba Centro", Convert.ToString(informeSI.L4ArribaCentro));
-            DatosPractica.Add("Roces L4 Abajo", Convert.ToString(informeSI.L4Abajo));
-            DatosPractica.Add("Roces L5", Convert.ToString(informeSI.L5));
-            DatosPractica.Add("Punciones Duramadre", Convert.ToString(informeSI.Duramadre));
-            DatosPractica.Add("Camino Correcto", Convert.ToString(informeSI.CaminoCorrecto));
-            DatosPractica.Add("Camino Incorrecto", Convert.ToString(informeSI.CaminoIncorrecto));
-            DatosPractica.Add("Tiempo Total", string.Format("{0:D2}:{1:D2}:{2:D2}",
-                tiempoTotalDeEjecucion.Hours, tiempoTotalDeEjecucion.Minutes, tiempoTotalDeEjecucion.Seconds));
+            DatosPractica = new OrderedDictionary
+            {
+                { "Contaminaciones Zona", Convert.ToString(informeZE.Zona) },
+                { "Contaminaciones Mano Izquierda", Convert.ToString(informeZE.ManoIzquierda) },
+                { "Contaminaciones Mano Derecha", Convert.ToString(informeZE.ManoDerecha) },
+                { "Punciones Tejido Adiposo", Convert.ToString(informeSI.TejidoAdiposo) },
+                { "Roces L2", Convert.ToString(informeSI.L2) },
+                { "Roces L3 Arriba", Convert.ToString(informeSI.L3Arriba) },
+                { "Roces L3 Abajo", Convert.ToString(informeSI.L3Abajo) },
+                { "Roces L4 Arriba Izquierda", Convert.ToString(informeSI.L4ArribaIzquierda) },
+                { "Roces L4 Arriba Derecha", Convert.ToString(informeSI.L4ArribaDerecha) },
+                { "Roces L4 Arriba Centro", Convert.ToString(informeSI.L4ArribaCentro) },
+                { "Roces L4 Abajo", Convert.ToString(informeSI.L4Abajo) },
+                { "Roces L5", Convert.ToString(informeSI.L5) },
+                { "Punciones Duramadre", Convert.ToString(informeSI.Duramadre) },
+                { "Camino Correcto", Convert.ToString(informeSI.CaminoCorrecto) },
+                { "Camino Incorrecto", Convert.ToString(informeSI.CaminoIncorrecto) },
+                {
+                    "Tiempo Total",
+                    string.Format("{0:D2}:{1:D2}:{2:D2}",
+                tiempoTotalDeEjecucion.Hours, tiempoTotalDeEjecucion.Minutes, tiempoTotalDeEjecucion.Seconds)
+                }
+            };
         }
     }
 }

--- a/LumbApp/Models/Informe.cs
+++ b/LumbApp/Models/Informe.cs
@@ -17,8 +17,8 @@ namespace LumbApp.Models
         public string FolderPath { get; private set; }
         public OrderedDictionary DatosPractica { get; private set; }
         public bool PdfGenerado { get; private set; }
-        
-        public Informe(string nombre, string apellido, int dni, string folderPath, InformeSI informeSI, 
+
+        public Informe(string nombre, string apellido, int dni, string folderPath, InformeSI informeSI,
             InformeZE informeZE, TimeSpan tiempoTotalDeEjecucion)
         {
             Nombre = nombre;
@@ -31,9 +31,10 @@ namespace LumbApp.Models
 
         public void SetPdfGenerado(bool pdfGenerado) { PdfGenerado = pdfGenerado; }
 
-        private void ArmarDiccionarioOrdenado (InformeSI informeSI, InformeZE informeZE, TimeSpan tiempoTotalDeEjecucion) {
+        private void ArmarDiccionarioOrdenado(InformeSI informeSI, InformeZE informeZE, TimeSpan tiempoTotalDeEjecucion)
+        {
             DatosPractica = new OrderedDictionary();
-            
+
 
             DatosPractica.Add("Contaminaciones Zona", Convert.ToString(informeZE.Zona));
             DatosPractica.Add("Contaminaciones Mano Izquierda", Convert.ToString(informeZE.ManoIzquierda));

--- a/LumbApp/Orquestador/IOrquestador.cs
+++ b/LumbApp/Orquestador/IOrquestador.cs
@@ -1,11 +1,4 @@
 ﻿using LumbApp.Enums;
-using LumbApp.Expertos.ExpertoSI;
-using LumbApp.Expertos.ExpertoZE;
-using LumbApp.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace LumbApp.Orquestador

--- a/LumbApp/Orquestador/IOrquestador.cs
+++ b/LumbApp/Orquestador/IOrquestador.cs
@@ -8,8 +8,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LumbApp.Orquestador {
-    public interface IOrquestador {
+namespace LumbApp.Orquestador
+{
+    public interface IOrquestador
+    {
         //void Start ();
         void SetDatosDeSimulacion(Models.DatosPracticante datosPracticante, ModoSimulacion modo);
         void IniciarSimulacion();

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -50,10 +50,9 @@ namespace LumbApp.Orquestador
 
 		}
 
-		public void SetDatosDeSimulacion(Models.DatosPracticante datosPracticante, ModoSimulacion modo)
+		public void SetDatosDeSimulacion(DatosPracticante datosPracticante, ModoSimulacion modo)
 		{
 			this.datosPracticante = datosPracticante;
-		
 			this.modoSeleccionado = modo;
 		}
 
@@ -62,11 +61,9 @@ namespace LumbApp.Orquestador
 		/// 
 		/// </summary>
 		public void IniciarSimulacion () {
-
+			Console.WriteLine("Iniciando simulacion en " + modoSeleccionado);
 			expertoZE.IniciarSimulacion();
-
 			expertoSI.IniciarSimulacion();
-
 
 			if(modoSeleccionado == ModoSimulacion.ModoGuiado)
 				IGUIController.IniciarSimulacionModoGuiado();
@@ -84,7 +81,7 @@ namespace LumbApp.Orquestador
 		/// </summary>
 		/// <returns></returns>
 		public async Task Inicializar() {
-
+			Console.WriteLine("Inicializando...");
 			try {
 				//INICIALIZAR EXPERTO ZE
 				expertoZE.CambioZE += CambioZE; //suscripción al evento CambioZE
@@ -104,6 +101,7 @@ namespace LumbApp.Orquestador
 				if(ex.Message.Contains("sensores"))
 					expertoSI.CambioSI -= CambioSI;
 
+				Console.WriteLine("Error de inicializacion: " + ex);
 				IGUIController.MostrarErrorDeConexion(ex.Message);
 			}
 			
@@ -121,7 +119,7 @@ namespace LumbApp.Orquestador
 		/// </summary>
 		public async Task TerminarSimulacion() { //Funcion llamada por la GUI, devuelve void, respuesta por evento
 												 //ExpertoZE.terminarSimulacion()
-
+			Console.WriteLine("Terminando simulacion...");
 			InformeZE informeZE = expertoZE.TerminarSimulacion();
 			InformeSI informeSI = expertoSI.TerminarSimulacion();
 

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -18,11 +18,8 @@ namespace LumbApp.Orquestador
 		private IExpertoZE expertoZE;
 		private IExpertoSI expertoSI;
 
-		private Models.DatosPracticante datosPracticante;
+		private DatosPracticante datosPracticante;
 		private ModoSimulacion modoSeleccionado;
-
-		private IConectorKinect conectorKinect;
-		private IConectorSI conectorSI;
 
 		private DateTime tiempoInicialDeEjecucion;
 		private TimeSpan tiempoTotalDeEjecucion;
@@ -44,11 +41,11 @@ namespace LumbApp.Orquestador
 				//Acá debería haber un nuevo mensaje por pantalla que me permita quitar las app, esto es incluso antes de la inicialización, asíq ue no puedo reintentar.
 				throw new Exception("Error al tratar de cargar el archivo de calibracion.");
 			}
-			conectorKinect = new ConectorKinect();
+			var conectorKinect = new ConectorKinect();
 			expertoZE = new ExpertoZE(conectorKinect, calibracion);
 
 			//conectorSI = new ConectorSI();
-			conectorSI = new ConectorSIMock(true);
+			var conectorSI = new ConectorSIMock(true);
 			expertoSI = new ExpertoSI(conectorSI);
 
 		}

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -13,158 +13,170 @@ using System.Threading.Tasks;
 
 namespace LumbApp.Orquestador
 {
-    public class Orquestador : IOrquestador {
-		public IGUIController IGUIController { get; set; }
+    public class Orquestador : IOrquestador
+    {
+        public IGUIController IGUIController { get; set; }
 
-		private IExpertoZE expertoZE;
-		private IExpertoSI expertoSI;
+        private IExpertoZE expertoZE;
+        private IExpertoSI expertoSI;
 
-		private DatosPracticante datosPracticante;
-		private ModoSimulacion modoSeleccionado;
+        private DatosPracticante datosPracticante;
+        private ModoSimulacion modoSeleccionado;
 
-		private DateTime tiempoInicialDeEjecucion;
-		private TimeSpan tiempoTotalDeEjecucion;
+        private DateTime tiempoInicialDeEjecucion;
+        private TimeSpan tiempoTotalDeEjecucion;
 
-		private IFinalFeedbacker ffb;
-		private string ruta;
+        private IFinalFeedbacker ffb;
+        private string ruta;
 
-		/// <summary>
-		/// Constructor del Orquestrador.
-		/// Se encarga de construir los expertos y la GUI manejando para manejar la comunicación entre ellos.
-		/// </summary>
-		public Orquestador (IGUIController gui, IConectorFS conectorFS) {
-			if (gui == null)
-				throw new Exception("Gui no puede ser null. Necesito un GUIController para crear un Orquestador.");
-			IGUIController = gui;
-			Calibracion calibracion;
-			try
-			{
-				calibracion = conectorFS.LevantarArchivoDeTextoComoObjeto<Calibracion>("./zonaEsteril.json");
-			}catch(Exception e){
-				Console.WriteLine(e);
-				//Acá debería haber un nuevo mensaje por pantalla que me permita quitar las app, esto es incluso antes de la inicialización, asíq ue no puedo reintentar.
-				throw new Exception("Error al tratar de cargar el archivo de calibracion.");
-			}
-			var conectorKinect = new ConectorKinect();
-			expertoZE = new ExpertoZE(conectorKinect, calibracion);
-			//expertoZE = new ExpertoZEMock(true);
+        /// <summary>
+        /// Constructor del Orquestrador.
+        /// Se encarga de construir los expertos y la GUI manejando para manejar la comunicación entre ellos.
+        /// </summary>
+        public Orquestador(IGUIController gui, IConectorFS conectorFS)
+        {
+            if (gui == null)
+                throw new Exception("Gui no puede ser null. Necesito un GUIController para crear un Orquestador.");
+            IGUIController = gui;
+            Calibracion calibracion;
+            try
+            {
+                calibracion = conectorFS.LevantarArchivoDeTextoComoObjeto<Calibracion>("./zonaEsteril.json");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                //Acá debería haber un nuevo mensaje por pantalla que me permita quitar las app, esto es incluso antes de la inicialización, asíq ue no puedo reintentar.
+                throw new Exception("Error al tratar de cargar el archivo de calibracion.");
+            }
+            var conectorKinect = new ConectorKinect();
+            expertoZE = new ExpertoZE(conectorKinect, calibracion);
+            //expertoZE = new ExpertoZEMock(true);
 
-			var conectorSI = new ConectorSI();
-			expertoSI = new ExpertoSI(conectorSI);
-			//expertoSI = new ExpertoSIMock(true);
-		}
+            var conectorSI = new ConectorSI();
+            expertoSI = new ExpertoSI(conectorSI);
+            //expertoSI = new ExpertoSIMock(true);
+        }
 
-		public void SetDatosDeSimulacion(DatosPracticante datosPracticante, ModoSimulacion modo)
-		{
-			this.datosPracticante = datosPracticante;
-			this.modoSeleccionado = modo;
-		}
+        public void SetDatosDeSimulacion(DatosPracticante datosPracticante, ModoSimulacion modo)
+        {
+            this.datosPracticante = datosPracticante;
+            this.modoSeleccionado = modo;
+        }
 
-		/// <summary>
-		/// IniciarSimulacion: Informa a los expertos que deben inicar el sensado.
-		/// 
-		/// </summary>
-		public void IniciarSimulacion ()
-		{
-			Console.WriteLine("Iniciando simulacion en " + modoSeleccionado);
-			tiempoInicialDeEjecucion = DateTime.Now;
-			ruta = ObtenerRuta(tiempoInicialDeEjecucion);
+        /// <summary>
+        /// IniciarSimulacion: Informa a los expertos que deben inicar el sensado.
+        /// 
+        /// </summary>
+        public void IniciarSimulacion()
+        {
+            Console.WriteLine("Iniciando simulacion en " + modoSeleccionado);
+            tiempoInicialDeEjecucion = DateTime.Now;
+            ruta = ObtenerRuta(tiempoInicialDeEjecucion);
 
-			expertoZE.IniciarSimulacion(new Video(ruta + ".mp4"));
-			expertoSI.IniciarSimulacion();
+            expertoZE.IniciarSimulacion(new Video(ruta + ".mp4"));
+            expertoSI.IniciarSimulacion();
 
-			if(modoSeleccionado == ModoSimulacion.ModoGuiado)
-				IGUIController.IniciarSimulacionModoGuiado();
-			else
-				IGUIController.IniciarSimulacionModoEvaluacion();
-		}
+            if (modoSeleccionado == ModoSimulacion.ModoGuiado)
+                IGUIController.IniciarSimulacionModoGuiado();
+            else
+                IGUIController.IniciarSimulacionModoEvaluacion();
+        }
 
-		/// <summary>
-		/// Inicializar: Se encarga de mandar a inicializar los expertos y pedir la pantalla de ingreso de datos.
-		/// - Si algun experto no pudo inicializar correctamente, envía a la GUI un mensaje de error.
-		/// - Sucede al abrir la aplicación. La GUI muestra un gif "checkeando sensores" y nos manda a inicializar.
-		/// </summary>
-		/// <returns></returns>
-		public async Task Inicializar() {
-			Console.WriteLine("Inicializando...");
-			try {
-				//INICIALIZAR EXPERTO ZE
-				expertoZE.CambioZE += CambioZE; //suscripción al evento CambioZE
-				if (!expertoZE.Inicializar())
-					throw new Exception("No se pudo detectar correctamente la kinect.");
+        /// <summary>
+        /// Inicializar: Se encarga de mandar a inicializar los expertos y pedir la pantalla de ingreso de datos.
+        /// - Si algun experto no pudo inicializar correctamente, envía a la GUI un mensaje de error.
+        /// - Sucede al abrir la aplicación. La GUI muestra un gif "checkeando sensores" y nos manda a inicializar.
+        /// </summary>
+        /// <returns></returns>
+        public async Task Inicializar()
+        {
+            Console.WriteLine("Inicializando...");
+            try
+            {
+                //INICIALIZAR EXPERTO ZE
+                expertoZE.CambioZE += CambioZE; //suscripción al evento CambioZE
+                if (!expertoZE.Inicializar())
+                    throw new Exception("No se pudo detectar correctamente la kinect.");
 
-				//INICIALIZAR EXPERTO SI
-				expertoSI.CambioSI += CambioSI; //suscripción al evento CambioSI
-				if (!expertoSI.Inicializar())
-					throw new Exception("No se pudieron detectar correctamente los sensores internos.");
+                //INICIALIZAR EXPERTO SI
+                expertoSI.CambioSI += CambioSI; //suscripción al evento CambioSI
+                if (!expertoSI.Inicializar())
+                    throw new Exception("No se pudieron detectar correctamente los sensores internos.");
 
-				//Mostrar pantalla de ingreso de datos, le mandamos el path por default donde se guarda la practica
-				IGUIController.SolicitarDatosPracticante("C:\\Desktop");
+                //Mostrar pantalla de ingreso de datos, le mandamos el path por default donde se guarda la practica
+                IGUIController.SolicitarDatosPracticante("C:\\Desktop");
 
-			} catch (Exception ex) {
-				expertoZE.CambioZE -= CambioZE;
-				if(ex.Message.Contains("sensores"))
-					expertoSI.CambioSI -= CambioSI;
+            }
+            catch (Exception ex)
+            {
+                expertoZE.CambioZE -= CambioZE;
+                if (ex.Message.Contains("sensores"))
+                    expertoSI.CambioSI -= CambioSI;
 
-				Console.WriteLine("Error de inicializacion: " + ex);
-				IGUIController.MostrarErrorDeConexion(ex.Message);
-			}
-			
-		}
+                Console.WriteLine("Error de inicializacion: " + ex);
+                IGUIController.MostrarErrorDeConexion(ex.Message);
+            }
 
-		public async Task NuevaSimulacion()
-		{ //Funcion llamada por la GUI, devuelve void, respuesta por evento
-			IGUIController.SolicitarDatosPracticante(datosPracticante.FolderPath);
-		}
+        }
 
-		/// <summary>
-		/// Terminar simulación: indica a los expertos que dejen de tomar estadísticas y devuelvan la informacion que obtuvo cada uno.
-		/// - Con la informacion regida genera un informe general que se envia al final feedbacker y se guarda.
-		/// - Si el informe general se genero y guardo bien, levanta un evento ue es atrapado por la GUI para decirle que todo salio bien.
-		/// </summary>
-		public async Task TerminarSimulacion() { //Funcion llamada por la GUI, devuelve void, respuesta por evento
-			Console.WriteLine("Terminando simulacion...");
-			InformeZE informeZE = expertoZE.TerminarSimulacion();
-			InformeSI informeSI = expertoSI.TerminarSimulacion();
+        public async Task NuevaSimulacion()
+        { //Funcion llamada por la GUI, devuelve void, respuesta por evento
+            IGUIController.SolicitarDatosPracticante(datosPracticante.FolderPath);
+        }
 
-			DateTime tiempoFinal = DateTime.Now;
-			tiempoTotalDeEjecucion = tiempoFinal - tiempoInicialDeEjecucion;
+        /// <summary>
+        /// Terminar simulación: indica a los expertos que dejen de tomar estadísticas y devuelvan la informacion que obtuvo cada uno.
+        /// - Con la informacion regida genera un informe general que se envia al final feedbacker y se guarda.
+        /// - Si el informe general se genero y guardo bien, levanta un evento ue es atrapado por la GUI para decirle que todo salio bien.
+        /// </summary>
+        public async Task TerminarSimulacion()
+        { //Funcion llamada por la GUI, devuelve void, respuesta por evento
+            Console.WriteLine("Terminando simulacion...");
+            InformeZE informeZE = expertoZE.TerminarSimulacion();
+            InformeSI informeSI = expertoSI.TerminarSimulacion();
 
-			Informe informeFinal = new Informe(
-				this.datosPracticante.Nombre,
-				this.datosPracticante.Apellido,
-				this.datosPracticante.Dni,
-				this.datosPracticante.FolderPath,
-				informeSI, informeZE, tiempoTotalDeEjecucion
-				);
+            DateTime tiempoFinal = DateTime.Now;
+            tiempoTotalDeEjecucion = tiempoFinal - tiempoInicialDeEjecucion;
 
-			ffb = new FinalFeedbacker(ruta + ".pdf", datosPracticante, informeFinal.DatosPractica, tiempoFinal);
-			informeFinal.SetPdfGenerado(ffb.GenerarPDF());
-			informeZE.Video.Save();
+            Informe informeFinal = new Informe(
+                this.datosPracticante.Nombre,
+                this.datosPracticante.Apellido,
+                this.datosPracticante.Dni,
+                this.datosPracticante.FolderPath,
+                informeSI, informeZE, tiempoTotalDeEjecucion
+                );
 
-			IGUIController.MostrarResultados(informeFinal);
+            ffb = new FinalFeedbacker(ruta + ".pdf", datosPracticante, informeFinal.DatosPractica, tiempoFinal);
+            informeFinal.SetPdfGenerado(ffb.GenerarPDF());
+            informeZE.Video.Save();
 
-			//Informar a GUI con informe con un evento, que pase si el informe se genero bien, y si se guardó  bien (bool, bool)
-		}
+            IGUIController.MostrarResultados(informeFinal);
 
-        private string ObtenerRuta (DateTime tiempo) {
-			string ruta = datosPracticante.FolderPath;
-			string carpetaAlumno = datosPracticante.Apellido + "_" + datosPracticante.Nombre + "_" + datosPracticante.Dni;
+            //Informar a GUI con informe con un evento, que pase si el informe se genero bien, y si se guardó  bien (bool, bool)
+        }
 
-			string nombreArchivos = string.Format("{0:D4}-{1:D2}-{2:D2}_{3:D2}-{4:D2}_{5}",
-				tiempo.Year, tiempo.Month, tiempo.Day, tiempo.Hour.ToString(), tiempo.Minute, datosPracticante.Apellido);
+        private string ObtenerRuta(DateTime tiempo)
+        {
+            string ruta = datosPracticante.FolderPath;
+            string carpetaAlumno = datosPracticante.Apellido + "_" + datosPracticante.Nombre + "_" + datosPracticante.Dni;
 
-			if (!ruta.Contains(carpetaAlumno)) {
-				ruta += ("\\" + carpetaAlumno);
-				if (!Directory.Exists(ruta)) {
-					Console.WriteLine("Creando el directorio: {0}", ruta);
-					Directory.CreateDirectory(ruta);
-				}
-			}
-			ruta += ("\\" + nombreArchivos);
+            string nombreArchivos = string.Format("{0:D4}-{1:D2}-{2:D2}_{3:D2}-{4:D2}_{5}",
+                tiempo.Year, tiempo.Month, tiempo.Day, tiempo.Hour.ToString(), tiempo.Minute, datosPracticante.Apellido);
 
-			return ruta;
-		}
+            if (!ruta.Contains(carpetaAlumno))
+            {
+                ruta += ("\\" + carpetaAlumno);
+                if (!Directory.Exists(ruta))
+                {
+                    Console.WriteLine("Creando el directorio: {0}", ruta);
+                    Directory.CreateDirectory(ruta);
+                }
+            }
+            ruta += ("\\" + nombreArchivos);
+
+            return ruta;
+        }
 
 
         /// <summary>
@@ -174,29 +186,33 @@ namespace LumbApp.Orquestador
         /// </summary>
         /// <param name="sender"> Remitente del evento </param>
         /// <param name="datosDelEvento"> Datos del cambio (capas, vertebras y correctitud del camino) </param>
-        private void CambioSI(object sender, CambioSIEventArgs datosDelEvento) {
-			//comunicar los cambios a la GUI levantando un evento
-			if (modoSeleccionado == ModoSimulacion.ModoGuiado)
-				IGUIController.MostrarCambioSI(datosDelEvento);
-		}
-
-		private void CambioZE(object sender, CambioZEEventArgs e) {
-			//comunicar los cambios a la GUI levantando un evento
-			if (modoSeleccionado == ModoSimulacion.ModoGuiado)
-				IGUIController.MostrarCambioZE(e);
-		}
-
-        public IExpertoSI GetExpertoSI () {
-			return expertoSI;
-        }
-		public void SetExpertoSI (IExpertoSI exp) {
-			this.expertoSI = exp;
+        private void CambioSI(object sender, CambioSIEventArgs datosDelEvento)
+        {
+            //comunicar los cambios a la GUI levantando un evento
+            if (modoSeleccionado == ModoSimulacion.ModoGuiado)
+                IGUIController.MostrarCambioSI(datosDelEvento);
         }
 
-		public void SetExpertoZE(IExpertoZE exp)
-		{
-			this.expertoZE = exp;
-		}
+        private void CambioZE(object sender, CambioZEEventArgs e)
+        {
+            //comunicar los cambios a la GUI levantando un evento
+            if (modoSeleccionado == ModoSimulacion.ModoGuiado)
+                IGUIController.MostrarCambioZE(e);
+        }
 
-	}
+        public IExpertoSI GetExpertoSI()
+        {
+            return expertoSI;
+        }
+        public void SetExpertoSI(IExpertoSI exp)
+        {
+            this.expertoSI = exp;
+        }
+
+        public void SetExpertoZE(IExpertoZE exp)
+        {
+            this.expertoZE = exp;
+        }
+
+    }
 }

--- a/UnitTestLumbapp/Conectores/TestConectorFS.cs
+++ b/UnitTestLumbapp/Conectores/TestConectorFS.cs
@@ -125,7 +125,8 @@ namespace UnitTestLumbapp.Conectores
         }
     }
 
-    public class ExampleClass {
+    public class ExampleClass
+    {
         public int _intExample { get; set; }
         public String _stringExample { get; set; }
         public bool _boolExample { get; set; }

--- a/UnitTestLumbapp/Conectores/TestConectorFS.cs
+++ b/UnitTestLumbapp/Conectores/TestConectorFS.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Text;
-using LumbApp.Expertos.ExpertoSI;
 using LumbApp.Conectores.ConectorFS;
 using Moq;
 using System.IO.Abstractions;

--- a/UnitTestLumbapp/Experto ZE/TestExpertoZE.cs
+++ b/UnitTestLumbapp/Experto ZE/TestExpertoZE.cs
@@ -3,8 +3,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using LumbApp.Expertos.ExpertoZE;
 using LumbApp.Conectores.ConectorKinect;
 using Moq;
-using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 
 namespace UnitTestLumbapp.Experto_ZE

--- a/UnitTestLumbapp/Experto ZE/TestExpertoZE.cs
+++ b/UnitTestLumbapp/Experto ZE/TestExpertoZE.cs
@@ -103,8 +103,8 @@ namespace UnitTestLumbapp.Experto_ZE
             ExpertoZE exp = new ExpertoZE(conn.Object, newCalibracion());
             exp.Inicializar();
 
-                bool init = exp.IniciarSimulacion(videoMock.Object);
-                Assert.AreEqual(true, init);
+            bool init = exp.IniciarSimulacion(videoMock.Object);
+            Assert.AreEqual(true, init);
         }
 
         /// <summary>

--- a/UnitTestLumbapp/Experto ZE/TestExpertoZE.cs
+++ b/UnitTestLumbapp/Experto ZE/TestExpertoZE.cs
@@ -20,7 +20,7 @@ namespace UnitTestLumbapp.Experto_ZE
             "Kinect no puede ser null. Necesito un conector a una kinect para crear un experto en zona esteril")]
         public void TestConstructorNull()
         {
-            ExpertoZE exp = new ExpertoZE(null, null);
+            _ = new ExpertoZE(null, null);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace UnitTestLumbapp.Experto_ZE
         public void TestConstructorCalNull()
         {
             Mock<IConectorKinect> conn = new Mock<IConectorKinect>();
-            ExpertoZE exp = new ExpertoZE(conn.Object, null);
+            _ = new ExpertoZE(conn.Object, null);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace UnitTestLumbapp.Experto_ZE
         public void TestConstructorOK()
         {
             Mock<IConectorKinect> conn = new Mock<IConectorKinect>();
-            ExpertoZE exp = new ExpertoZE(conn.Object, newCalibracion());
+            _ = new ExpertoZE(conn.Object, newCalibracion());
         }
 
         private Calibracion newCalibracion()

--- a/UnitTestLumbapp/Experto ZE/TestZE.cs
+++ b/UnitTestLumbapp/Experto ZE/TestZE.cs
@@ -36,7 +36,7 @@ namespace UnitTestLumbapp.Experto_ZE
         [TestMethod]
         public void TestDentroZEFija()
         {
-            SkeletonPoint[] points = { 
+            SkeletonPoint[] points = {
                 newPoint(0,0,0), newPoint(0,0,1), newPoint(1, 0, 1),  newPoint(1,0,0),
                 newPoint(0,1,0), newPoint(0,1,1), newPoint(1, 1, 1),  newPoint(1,1,0)};
             Calibracion cal = new Calibracion(points);

--- a/UnitTestLumbapp/Experto_SI/TestCapa.cs
+++ b/UnitTestLumbapp/Experto_SI/TestCapa.cs
@@ -4,15 +4,18 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace UnitTestLumbapp.Experto_SI {
+namespace UnitTestLumbapp.Experto_SI
+{
     [TestClass]
-    public class TestCapa {
+    public class TestCapa
+    {
         /// <summary>
         /// La Capa debe cambiar de estado con Atavesar() y Abandonar().
         /// Los estados son Inicial, Atravesando, Abanonada y AtravesandoNuevamente.
         /// </summary>
         [TestMethod]
-        public void TestEstadoCapa () {
+        public void TestEstadoCapa()
+        {
             Capa capa = new Capa();
             bool cambio;
 

--- a/UnitTestLumbapp/Experto_SI/TestCapa.cs
+++ b/UnitTestLumbapp/Experto_SI/TestCapa.cs
@@ -1,8 +1,5 @@
 ﻿using LumbApp.Expertos.ExpertoSI.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace UnitTestLumbapp.Experto_SI
 {

--- a/UnitTestLumbapp/Experto_SI/TestExpertoSI.cs
+++ b/UnitTestLumbapp/Experto_SI/TestExpertoSI.cs
@@ -8,7 +8,8 @@ using LumbApp.Expertos.ExpertoSI.Utils;
 namespace UnitTestLumbapp.Experto_SI
 {
     [TestClass]
-    public class TestExpertoSI {
+    public class TestExpertoSI
+    {
 
         /// <summary>
         /// Si el constructor de Experto SI se llama con null, debe tirar excepcion.
@@ -16,7 +17,7 @@ namespace UnitTestLumbapp.Experto_SI
         [TestMethod]
         [ExpectedException(typeof(Exception),
             "Sensores no puede ser null. Necesito un conector a los sensores para crear un experto en sensores internos")]
-        public void TestConstructorNull ()
+        public void TestConstructorNull()
         {
             new ExpertoSI(null);
         }
@@ -25,7 +26,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si el constructor del Experto SI se llama con un conector, el resultado es OK.
         /// </summary>
         [TestMethod]
-        public void TestConstructorOK () {
+        public void TestConstructorOK()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             ExpertoSI exp = new ExpertoSI(conn.Object);
         }
@@ -34,7 +36,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si en Inicializar pasa todo OK debe devolver true.
         /// </summary>
         [TestMethod]
-        public void TestInicializarOK () {
+        public void TestInicializarOK()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.Conectar()).Returns(true);
             conn.Setup(x => x.CheckearComunicacion()).Returns(true);
@@ -49,7 +52,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// retornar false.
         /// </summary>
         [TestMethod]
-        public void TestInicializarConectarErr () {
+        public void TestInicializarConectarErr()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.Conectar()).Throws(new Exception());
             ExpertoSI exp = new ExpertoSI(conn.Object);
@@ -63,7 +67,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// la inicializacion debe retornar false.
         /// </summary>
         [TestMethod]
-        public void TestInicializarCheckeoErr () {
+        public void TestInicializarCheckeoErr()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.CheckearComunicacion()).Returns(false);
             ExpertoSI exp = new ExpertoSI(conn.Object);
@@ -76,7 +81,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si IniciarSimulacion se llama antes de Inicializar, debe devolver false.
         /// </summary>
         [TestMethod]
-        public void IniciarTooSoon () {
+        public void IniciarTooSoon()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
 
             ExpertoSI exp = new ExpertoSI(conn.Object);
@@ -89,7 +95,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si IniciarSimulacion esta OK debe devolver true
         /// </summary>
         [TestMethod]
-        public void IniciarOK () {
+        public void IniciarOK()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.Conectar()).Returns(true);
             conn.Setup(x => x.CheckearComunicacion()).Returns(true);
@@ -105,7 +112,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si se llama a TerminarSimulacion antes de Inicializar debe devolver un reporte vacio
         /// </summary>
         [TestMethod]
-        public void TerminarTooSoon1 () {
+        public void TerminarTooSoon1()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             ExpertoSI exp = new ExpertoSI(conn.Object);
 
@@ -113,7 +121,7 @@ namespace UnitTestLumbapp.Experto_SI
 
             Assert.AreEqual(0, informe.TejidoAdiposo);
             Assert.AreEqual(0, informe.L2);
-            
+
             Assert.AreEqual(0, informe.L3Arriba);
             Assert.AreEqual(0, informe.L3Abajo);
 
@@ -131,7 +139,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// vacio.
         /// </summary>
         [TestMethod]
-        public void TerminarTooSoon2 () {
+        public void TerminarTooSoon2()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.CheckearComunicacion()).Returns(true);
 
@@ -160,10 +169,11 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si no ocurrio nada, el reporte estara vacio.
         /// </summary>
         [TestMethod]
-        public void TerminarOkEnCeros () {
+        public void TerminarOkEnCeros()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.CheckearComunicacion()).Returns(true);
-            
+
             ExpertoSI exp = new ExpertoSI(conn.Object);
             exp.Inicializar();
             exp.IniciarSimulacion();
@@ -189,7 +199,8 @@ namespace UnitTestLumbapp.Experto_SI
         /// Si se llama a TerminarSimulacion todo OK, debe devolver un reporte con las cosas que ocurrieron.
         /// </summary>
         [TestMethod]
-        public void TerminarOk () {
+        public void TerminarOk()
+        {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
             conn.Setup(x => x.Conectar()).Returns(true);
             conn.Setup(x => x.CheckearComunicacion()).Returns(true);

--- a/UnitTestLumbapp/Experto_SI/TestExpertoSI.cs
+++ b/UnitTestLumbapp/Experto_SI/TestExpertoSI.cs
@@ -29,7 +29,7 @@ namespace UnitTestLumbapp.Experto_SI
         public void TestConstructorOK()
         {
             Mock<IConectorSI> conn = new Mock<IConectorSI>();
-            ExpertoSI exp = new ExpertoSI(conn.Object);
+            _ = new ExpertoSI(conn.Object);
         }
 
         /// <summary>

--- a/UnitTestLumbapp/Experto_SI/TestVertebra.cs
+++ b/UnitTestLumbapp/Experto_SI/TestVertebra.cs
@@ -4,16 +4,19 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace UnitTestLumbapp.Experto_SI {
+namespace UnitTestLumbapp.Experto_SI
+{
     [TestClass]
-    public class TestVertebra {
+    public class TestVertebra
+    {
         /// <summary>
         /// La Vertebra debe cambiar de estado con Rozar() y Abandonar().
         /// Los estados son Inicial, Rozando, Abandonada y RozandoNuevamente e incrementar el contador de veces rozada
         /// cuando hay un cambio de Inicial a Rozando o de Abandonada a RozandoNuevamente.
         /// </summary>
         [TestMethod]
-        public void TestEstadosYVecesVertebra () {
+        public void TestEstadosYVecesVertebra()
+        {
             Vertebra vertebra = new Vertebra();
             bool cambio;
 
@@ -75,7 +78,8 @@ namespace UnitTestLumbapp.Experto_SI {
         /// cuando hay un cambio de Inicial a Rozando o de Abandonada a RozandoNuevamente.
         /// </summary>
         [TestMethod]
-        public void TestEstadosYVecesVertebraL3 () {
+        public void TestEstadosYVecesVertebraL3()
+        {
             VertebraL3 vertebra = new VertebraL3();
             bool cambio;
 
@@ -137,7 +141,8 @@ namespace UnitTestLumbapp.Experto_SI {
         }
 
         [TestMethod]
-        public void TestSectoresYVecesVertebraL3 () {
+        public void TestSectoresYVecesVertebraL3()
+        {
             VertebraL3 vertebra = new VertebraL3();
 
             Assert.AreEqual(VertebraL3.Estados.Inicial, vertebra.Estado);
@@ -204,7 +209,8 @@ namespace UnitTestLumbapp.Experto_SI {
         /// cuando hay un cambio de Inicial a Rozando o de Abandonada a RozandoNuevamente.
         /// </summary>
         [TestMethod]
-        public void TestEstadosYVecesVertebraL4 () {
+        public void TestEstadosYVecesVertebraL4()
+        {
             VertebraL4 vertebra = new VertebraL4();
             bool cambio;
 
@@ -283,7 +289,8 @@ namespace UnitTestLumbapp.Experto_SI {
         }
 
         [TestMethod]
-        public void TestSectoresYVecesVertebraL4 () {
+        public void TestSectoresYVecesVertebraL4()
+        {
             VertebraL4 vertebra = new VertebraL4();
 
             Assert.AreEqual(VertebraL4.Estados.Inicial, vertebra.Estado);

--- a/UnitTestLumbapp/Experto_SI/TestVertebra.cs
+++ b/UnitTestLumbapp/Experto_SI/TestVertebra.cs
@@ -1,8 +1,5 @@
 ﻿using LumbApp.Expertos.ExpertoSI.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace UnitTestLumbapp.Experto_SI
 {

--- a/UnitTestLumbapp/UnitTestOrquestador.cs
+++ b/UnitTestLumbapp/UnitTestOrquestador.cs
@@ -133,10 +133,13 @@ namespace UnitTestLumbapp
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
+            Mock<IVideo> videoZE = new Mock<IVideo>();
             Mock<IGUIController> gui = new Mock<IGUIController>();
 
             expSI.Setup(x => x.Inicializar()).Returns(true);
+            expSI.Setup(x => x.TerminarSimulacion()).Returns(new InformeSI(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
             expZE.Setup(x => x.Inicializar()).Returns(true);
+            expZE.Setup(x => x.TerminarSimulacion()).Returns(new InformeZE(0,0,0,videoZE.Object));
 
             Orquestador orq = new Orquestador(gui.Object, mockedConectorFS());
             orq.SetExpertoSI(expSI.Object);

--- a/UnitTestLumbapp/UnitTestOrquestador.cs
+++ b/UnitTestLumbapp/UnitTestOrquestador.cs
@@ -12,16 +12,19 @@ using System.IO.Abstractions;
 using LumbApp.Conectores.ConectorFS;
 using LumbApp.Models;
 
-namespace UnitTestLumbapp {
+namespace UnitTestLumbapp
+{
     [TestClass]
-    public class UnitTestOrquestador {
+    public class UnitTestOrquestador
+    {
         /// <summary>
         /// Test que prueba el caso de intentar crear un orquestador sin una GUI, generando una exception
         /// </summary>
         [TestMethod]
         [ExpectedException(typeof(Exception),
             "Gui no puede ser null. Necesito un GUIController para crear un Orquestador.")]
-        public void TestConstructorNull () {
+        public void TestConstructorNull()
+        {
             Orquestador orq = new Orquestador(null, null);
         }
 
@@ -59,7 +62,7 @@ namespace UnitTestLumbapp {
             orq.SetExpertoZE(expZE.Object);
 
             orq.Inicializar();
-            gui.Verify(x => x.SolicitarDatosPracticante(It.IsAny<string>()), Times.Once) ;
+            gui.Verify(x => x.SolicitarDatosPracticante(It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]

--- a/UnitTestLumbapp/UnitTestOrquestador.cs
+++ b/UnitTestLumbapp/UnitTestOrquestador.cs
@@ -48,7 +48,7 @@ namespace UnitTestLumbapp
         }
 
         [TestMethod]
-        public void TestInicializarOk()
+        public async Task TestInicializarOk()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -61,12 +61,12 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
             gui.Verify(x => x.SolicitarDatosPracticante(It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]
-        public void TestIniciarSimulaciónModoEvaluacion()
+        public async Task TestIniciarSimulaciónModoEvaluacion()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -79,7 +79,7 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
 
             var datos = new DatosPracticante()
             {
@@ -98,7 +98,7 @@ namespace UnitTestLumbapp
         }
 
         [TestMethod]
-        public void TestIniciarSimulaciónModoGuiado()
+        public async Task TestIniciarSimulaciónModoGuiado()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -111,7 +111,7 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
             var datos = new DatosPracticante()
             {
                 Dni = 99999999,
@@ -129,7 +129,7 @@ namespace UnitTestLumbapp
         }
 
         [TestMethod]
-        public void TestTerminarSimulacion()
+        public async Task TestTerminarSimulacion()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -142,7 +142,7 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
 
             var datos = new DatosPracticante()
             {
@@ -159,13 +159,13 @@ namespace UnitTestLumbapp
             expZE.Verify(x => x.IniciarSimulacion(It.IsAny<IVideo>()), Times.Once);
             gui.Verify(x => x.IniciarSimulacionModoEvaluacion(), Times.Once);
 
-            orq.TerminarSimulacion();
+            await orq.TerminarSimulacion();
             expSI.Verify(x => x.TerminarSimulacion(), Times.Once);
             expZE.Verify(x => x.TerminarSimulacion(), Times.Once);
         }
 
         [TestMethod]
-        public void TestInformeGenerico()
+        public async Task TestInformeGenerico()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -178,7 +178,7 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
 
             DatosPracticante dp = new DatosPracticante();
             dp.Dni = 39879304;
@@ -195,7 +195,7 @@ namespace UnitTestLumbapp
             expSI.Setup(x => x.TerminarSimulacion()).Returns(informeSI);
             expZE.Setup(x => x.TerminarSimulacion()).Returns(informeZE);
 
-            orq.TerminarSimulacion();
+            await orq.TerminarSimulacion();
             gui.Verify(x => x.MostrarResultados(It.IsAny<Informe>()), Times.Once);
         }
 
@@ -264,7 +264,7 @@ namespace UnitTestLumbapp
         }
 
         [TestMethod]
-        public void TestInicializarSIErrAsyncInSI()
+        public async Task TestInicializarSIErrAsyncInSI()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -277,12 +277,12 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
             gui.Verify(x => x.MostrarErrorDeConexion(It.IsAny<String>()), Times.Once);
         }
 
         [TestMethod]
-        public void TestInicializarSIErrAsyncInZE()
+        public async Task TestInicializarSIErrAsyncInZE()
         {
             Mock<IExpertoSI> expSI = new Mock<IExpertoSI>();
             Mock<IExpertoZE> expZE = new Mock<IExpertoZE>();
@@ -295,7 +295,7 @@ namespace UnitTestLumbapp
             orq.SetExpertoSI(expSI.Object);
             orq.SetExpertoZE(expZE.Object);
 
-            orq.Inicializar();
+            await orq.Inicializar();
             gui.Verify(x => x.MostrarErrorDeConexion(It.IsAny<String>()), Times.Once);
         }
 

--- a/UnitTestLumbapp/UnitTestOrquestador.cs
+++ b/UnitTestLumbapp/UnitTestOrquestador.cs
@@ -25,7 +25,7 @@ namespace UnitTestLumbapp
             "Gui no puede ser null. Necesito un GUIController para crear un Orquestador.")]
         public void TestConstructorNull()
         {
-            Orquestador orq = new Orquestador(null, null);
+            _ = new Orquestador(null, null);
         }
 
         /// <summary>
@@ -37,14 +37,14 @@ namespace UnitTestLumbapp
         public void TestConstructorSinCalibracion()
         {
             Mock<IGUIController> gui = new Mock<IGUIController>();
-            IOrquestador orq = new Orquestador(gui.Object, null);
+            _ = new Orquestador(gui.Object, null);
         }
 
         [TestMethod]
         public void TestConstructorOK()
         {
             Mock<IGUIController> gui = new Mock<IGUIController>();
-            IOrquestador orq = new Orquestador(gui.Object, mockedConectorFS());
+            _ = new Orquestador(gui.Object, mockedConectorFS());
         }
 
         [TestMethod]
@@ -183,11 +183,13 @@ namespace UnitTestLumbapp
 
             await orq.Inicializar();
 
-            DatosPracticante dp = new DatosPracticante();
-            dp.Dni = 39879304;
-            dp.Nombre = "Alexis";
-            dp.Apellido = "Aranda";
-            dp.FolderPath = ".\\folder";
+            DatosPracticante dp = new DatosPracticante
+            {
+                Dni = 39879304,
+                Nombre = "Alexis",
+                Apellido = "Aranda",
+                FolderPath = ".\\folder"
+            };
 
             orq.SetDatosDeSimulacion(dp, LumbApp.Enums.ModoSimulacion.ModoEvaluacion);
             orq.IniciarSimulacion();
@@ -218,11 +220,13 @@ namespace UnitTestLumbapp
 
             await orq.Inicializar();
 
-            DatosPracticante dp = new DatosPracticante();
-            dp.Dni = 39879304;
-            dp.Nombre = "Alexis";
-            dp.Apellido = "Aranda";
-            dp.FolderPath = ".\\folder";
+            DatosPracticante dp = new DatosPracticante
+            {
+                Dni = 39879304,
+                Nombre = "Alexis",
+                Apellido = "Aranda",
+                FolderPath = ".\\folder"
+            };
 
             orq.SetDatosDeSimulacion(dp, LumbApp.Enums.ModoSimulacion.ModoEvaluacion);
             orq.IniciarSimulacion();


### PR DESCRIPTION
Agrego logs, soluciono muuuchos warnings y le doy format (ctrl+K, ctrl+D) a todos los documentos para normalizar tabs y espacios.

En la vista de files del PR, arriba (pero debajo de las pestañas) hay un engranaje de settings. Tiene la opcion de no mostrar cambios de espacios en el diff. Eso puede ayudar a no marearse con el PR.

Tipos de warnings que fixie (son todos fixes automaticos que sugiere visual studio):
- Borre usings de que no se usaban
- Cuando hacemos `new` y despues a ese objeto le hacemos `obj.prop = algo`, eso se puede escribir de una forma mas legible entre llaves. Lo cambie para los que tenian mas de 3 lineas.
- Simplifique los usos de delegados
- Agregue readonly a todo lo que no cambiaba su valor despues de la primer asignacion
- Cuando se llamaba a una funcion async y tiraba warning de que no habia await, puse `_ =` para descartarlo explicitamente
- A los tests les puse await y los volvi asincronicos. Esto hizo saltar errores que no saltaban por la concurrencia (el test terminaba antes de que aparezca la excepcion)