### PR TITLE
Fix: video freeze

### DIFF
--- a/LumbApp/GUI/GUIController.cs
+++ b/LumbApp/GUI/GUIController.cs
@@ -139,5 +139,10 @@ namespace LumbApp.GUI
             ResultadosSimulacionPage.MostrarResultados(informe);
         }
 
+        public void ResultadosGuardados()
+        {
+            ResultadosSimulacionPage.ResultadosGuardados();
+        }
+
     }
 }

--- a/LumbApp/GUI/IGUIController.cs
+++ b/LumbApp/GUI/IGUIController.cs
@@ -15,5 +15,6 @@ namespace LumbApp.GUI
         void IniciarSimulacionModoGuiado();
         void MostrarCambioSI(CambioSIEventArgs datosDelEvento);
         void MostrarResultados(Informe informe);
+        void ResultadosGuardados();
     }
 }

--- a/LumbApp/GUI/ResultadosSimulacion.xaml.cs
+++ b/LumbApp/GUI/ResultadosSimulacion.xaml.cs
@@ -52,5 +52,10 @@ namespace LumbApp.GUI
                 i++;
             }
         }
+
+        public void ResultadosGuardados()
+        {
+            //TODO
+        }
     }
 }

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -167,38 +167,33 @@ namespace LumbApp.Orquestador
         public async Task TerminarSimulacion()
         {
             Console.WriteLine("Terminando simulacion...");
+            DateTime tiempoFinal = DateTime.Now;
+            tiempoTotalDeEjecucion = tiempoFinal - tiempoInicialDeEjecucion;
 
             // Crear el informe
-            var tInforme = Task.Run(() =>
-            {
-                InformeZE informeZE = expertoZE.TerminarSimulacion();
-                InformeSI informeSI = expertoSI.TerminarSimulacion();
 
-                DateTime tiempoFinal = DateTime.Now;
-                tiempoTotalDeEjecucion = tiempoFinal - tiempoInicialDeEjecucion;
+            InformeZE informeZE = expertoZE.TerminarSimulacion();
+            InformeSI informeSI = expertoSI.TerminarSimulacion();
 
-                Informe informeFinal = new Informe(
-                    this.datosPracticante.Nombre,
-                    this.datosPracticante.Apellido,
-                    this.datosPracticante.Dni,
-                    this.datosPracticante.FolderPath,
-                    informeSI, informeZE, tiempoTotalDeEjecucion
-                    );
+            Informe informeFinal = new Informe(
+                this.datosPracticante.Nombre,
+                this.datosPracticante.Apellido,
+                this.datosPracticante.Dni,
+                this.datosPracticante.FolderPath,
+                informeSI, informeZE, tiempoTotalDeEjecucion
+                );
 
-                return informeFinal;
-            });
 
-            var informe = await tInforme;
-            IGUIController.MostrarResultados(informe);
+            IGUIController.MostrarResultados(informeFinal);
 
             // Guardar PDF y video
-            var tFiles = Task.Run(Informe informeFinal =>
+            await Task.Run(() =>
             {
                 _ffb = new FinalFeedbacker(ruta + ".pdf", datosPracticante, informeFinal.DatosPractica, tiempoFinal);
                 informeFinal.SetPdfGenerado(_ffb.GenerarPDF());
                 informeZE.Video.Save();
             });
-            
+            IGUIController.ResultadosGuardados();
         }
 
         /// <summary>

--- a/LumbApp/Orquestador/Orquestador.cs
+++ b/LumbApp/Orquestador/Orquestador.cs
@@ -166,9 +166,11 @@ namespace LumbApp.Orquestador
         /// </summary>
         public async Task TerminarSimulacion()
         {
-            var task = Task.Run(() =>
+            Console.WriteLine("Terminando simulacion...");
+
+            // Crear el informe
+            var tInforme = Task.Run(() =>
             {
-                Console.WriteLine("Terminando simulacion...");
                 InformeZE informeZE = expertoZE.TerminarSimulacion();
                 InformeSI informeSI = expertoSI.TerminarSimulacion();
 
@@ -183,14 +185,20 @@ namespace LumbApp.Orquestador
                     informeSI, informeZE, tiempoTotalDeEjecucion
                     );
 
-                _ffb = new FinalFeedbacker(ruta + ".pdf", datosPracticante, informeFinal.DatosPractica, tiempoFinal);
-                informeFinal.SetPdfGenerado(_ffb.GenerarPDF());
-                informeZE.Video.Save();
                 return informeFinal;
             });
 
-            var informe = await task;
+            var informe = await tInforme;
             IGUIController.MostrarResultados(informe);
+
+            // Guardar PDF y video
+            var tFiles = Task.Run(Informe informeFinal =>
+            {
+                _ffb = new FinalFeedbacker(ruta + ".pdf", datosPracticante, informeFinal.DatosPractica, tiempoFinal);
+                informeFinal.SetPdfGenerado(_ffb.GenerarPDF());
+                informeZE.Video.Save();
+            });
+            
         }
 
         /// <summary>


### PR DESCRIPTION
Cuando se termina la simulacion, prioriza mostrar los resultados por pantalla. Queda guardando en segundo plano mientras el front ruega no cerrar la app.