### PR TITLE
Fix: nombre del arduino

### DIFF
--- a/LumbApp/Conectores/ConectorSI/ConectorSI.cs
+++ b/LumbApp/Conectores/ConectorSI/ConectorSI.cs
@@ -59,7 +59,7 @@ namespace LumbApp.Conectores.ConectorSI
                     string desc = item["Description"].ToString();
                     string deviceId = item["DeviceID"].ToString();
 
-                    if (desc.Contains("Dispositivo"))
+                    if (desc.Contains("Dispositivo") || desc.Contains("Arduino"))
                     {
                         return deviceId;
                     }


### PR DESCRIPTION
Subo el hotfix de ayer, donde le agregamos mas nombres al Arduino para que mi compu lo reconozca.