### PR TITLE
Fix: imagenes en instalador

### DIFF
--- a/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
@@ -66,10 +66,7 @@ namespace LumbApp.FinalFeedbacker_
                 try 
                 {
                     // Creamos la imagen y le ajustamos el tamaño
-                    var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..");
-                    path = Path.Combine(path, @"..\Images\logo.png");
-
-                    Image logo = Image.GetInstance(path);
+                    Image logo = Image.GetInstance(@".\Images\logo.png");
                     logo.ScaleToFit(100, 100F);
                     logo.SetAbsolutePosition(500, 750);
                     //logo.Alignment = Element.ALIGN_RIGHT;

--- a/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
+++ b/LumbApp/FinalFeedbacker_/FinalFeedbacker.cs
@@ -148,8 +148,7 @@ namespace LumbApp.FinalFeedbacker_
                 tblDatosAlumno.AddCell(columna3);
 
                 string fechaString = string.Format("{0:D2}/{1:D2}/{2:D2} {3:D2}:{4:D2}",
-                _fecha.Year.ToString(), _fecha.Month.ToString(), _fecha.Day.ToString(),
-                _fecha.Hour.ToString(), _fecha.Minute.ToString());
+                _fecha.Year, _fecha.Month, _fecha.Day, _fecha.Hour, _fecha.Minute);
 
                 columna4 = new PdfPCell(new Phrase(fechaString, _fuenteEstandar));
                 columna4.Border = Rectangle.NO_BORDER;

--- a/LumbApp/LumbApp.csproj
+++ b/LumbApp/LumbApp.csproj
@@ -380,6 +380,9 @@
     <Resource Include="GUI\Imagenes\Preparacion\rubber-gloves.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>
+    <Content Include="Images\logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="License-LGPL.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/LumbApp/LumbApp.csproj
+++ b/LumbApp/LumbApp.csproj
@@ -239,147 +239,147 @@
   <ItemGroup>
     <Content Include="Conectores\ConectorSI\conector.exe" />
     <Content Include="Expertos\ExpertoZE\Calibracion\binaries\Calibrador de LumbApp.exe" />
-    <Content Include="GUI\Imagenes\Capas\Costado\base.png">
+    <Resource Include="GUI\Imagenes\Capas\Costado\base.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\duramadre.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\duramadre.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L2 adelante.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L2 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L3 abajo.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L3 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L3 arriba.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L3 arriba.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L4 abajo.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L4 arriba centro.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba centro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L4 arriba derecha.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba derecha.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L4 arriba izquierda.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba izquierda.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\L5 adelante.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L5 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\piel_OFF.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\piel_OFF.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Costado\piel_ON.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\piel_ON.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\base.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\base.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\duramadre.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\duramadre.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L2 adelante.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L2 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L3 abajo.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L3 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L3 arriba.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L3 arriba.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L4 abajo.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L4 arriba centro.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba centro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L4 arriba derecha.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba derecha.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L4 arriba izquierda.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba izquierda.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Capas\Frente\L5 adelante.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L5 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada1.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada1.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada2.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada2.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada3.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada3.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada4.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada4.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada5.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada5.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada6.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada6.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada7.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada7.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-dentro.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-dentro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera-inicial.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera-inicial.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada1.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada1.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada2.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada2.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada3.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada3.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada4.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada4.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada5.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada5.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada6.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada6.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada7.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada7.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-dentro.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-dentro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-fuera-inicial.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera-inicial.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-fuera.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Preparacion\alcohol-gel.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\alcohol-gel.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Preparacion\cap-facemask-eye-protection.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\cap-facemask-eye-protection.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Preparacion\gown.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\gown.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Preparacion\handwashing.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\handwashing.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GUI\Imagenes\Preparacion\rubber-gloves.png">
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\rubber-gloves.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </Resource>
     <Content Include="Images\logo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/LumbApp/LumbApp.csproj
+++ b/LumbApp/LumbApp.csproj
@@ -239,53 +239,147 @@
   <ItemGroup>
     <Content Include="Conectores\ConectorSI\conector.exe" />
     <Content Include="Expertos\ExpertoZE\Calibracion\binaries\Calibrador de LumbApp.exe" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\base.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\duramadre.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L2 adelante.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L3 abajo.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L3 arriba.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 abajo.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba centro.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba derecha.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba izquierda.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\L5 adelante.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\piel_OFF.png" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\piel_ON.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\base.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\duramadre.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L2 adelante.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L3 abajo.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L3 arriba.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 abajo.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba centro.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba derecha.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba izquierda.png" />
-    <Resource Include="GUI\Imagenes\Capas\Frente\L5 adelante.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada1.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada2.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada3.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada4.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada5.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada6.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada7.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-dentro.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera-inicial.png" />
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada1.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada2.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada3.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada4.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada5.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada6.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada7.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-dentro.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera-inicial.png" />
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera.png" />
-    <Resource Include="GUI\Imagenes\Preparacion\alcohol-gel.png" />
-    <Resource Include="GUI\Imagenes\Preparacion\cap-facemask-eye-protection.png" />
-    <Resource Include="GUI\Imagenes\Preparacion\gown.png" />
-    <Resource Include="GUI\Imagenes\Preparacion\handwashing.png" />
-    <Resource Include="GUI\Imagenes\Preparacion\rubber-gloves.png" />
+    <Resource Include="GUI\Imagenes\Capas\Costado\base.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\duramadre.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L2 adelante.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L3 abajo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L3 arriba.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 abajo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba centro.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba derecha.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba izquierda.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\L5 adelante.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\piel_OFF.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Costado\piel_ON.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\base.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\duramadre.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L2 adelante.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L3 abajo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L3 arriba.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 abajo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba centro.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba derecha.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba izquierda.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Capas\Frente\L5 adelante.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada1.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada2.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada3.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada4.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada5.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada6.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada7.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-dentro.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera-inicial.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada1.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada2.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada3.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada4.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada5.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada6.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada7.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-dentro.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera-inicial.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\alcohol-gel.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\cap-facemask-eye-protection.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\gown.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\handwashing.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="GUI\Imagenes\Preparacion\rubber-gloves.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
     <Content Include="License-LGPL.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/LumbApp/LumbApp.csproj
+++ b/LumbApp/LumbApp.csproj
@@ -239,147 +239,147 @@
   <ItemGroup>
     <Content Include="Conectores\ConectorSI\conector.exe" />
     <Content Include="Expertos\ExpertoZE\Calibracion\binaries\Calibrador de LumbApp.exe" />
-    <Resource Include="GUI\Imagenes\Capas\Costado\base.png">
+    <Content Include="GUI\Imagenes\Capas\Costado\base.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\duramadre.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\duramadre.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L2 adelante.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L2 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L3 abajo.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L3 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L3 arriba.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L3 arriba.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 abajo.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L4 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba centro.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L4 arriba centro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba derecha.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L4 arriba derecha.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L4 arriba izquierda.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L4 arriba izquierda.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\L5 adelante.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\L5 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\piel_OFF.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\piel_OFF.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Costado\piel_ON.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Costado\piel_ON.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\base.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\base.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\duramadre.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\duramadre.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L2 adelante.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L2 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L3 abajo.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L3 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L3 arriba.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L3 arriba.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 abajo.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L4 abajo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba centro.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L4 arriba centro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba derecha.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L4 arriba derecha.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L4 arriba izquierda.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L4 arriba izquierda.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Capas\Frente\L5 adelante.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Capas\Frente\L5 adelante.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada1.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada1.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada2.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada2.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada3.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada3.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada4.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada4.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada5.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada5.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada6.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada6.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada7.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-contaminada7.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-dentro.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-dentro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera-inicial.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera-inicial.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\NoTraqueando\mano-fuera.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada1.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada1.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada2.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada2.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada3.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada3.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada4.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada4.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada5.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada5.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada6.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada6.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada7.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-contaminada7.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-dentro.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-dentro.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera-inicial.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-fuera-inicial.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Manos\Traqueando\mano-fuera.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Manos\Traqueando\mano-fuera.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Preparacion\alcohol-gel.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Preparacion\alcohol-gel.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Preparacion\cap-facemask-eye-protection.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Preparacion\cap-facemask-eye-protection.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Preparacion\gown.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Preparacion\gown.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Preparacion\handwashing.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Preparacion\handwashing.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="GUI\Imagenes\Preparacion\rubber-gloves.png">
+    </Content>
+    <Content Include="GUI\Imagenes\Preparacion\rubber-gloves.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
+    </Content>
     <Content Include="Images\logo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/LumbApp/LumbApp.sln
+++ b/LumbApp/LumbApp.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LumbApp", "LumbApp.csproj",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTestLumbapp", "..\UnitTestLumbapp\UnitTestLumbapp.csproj", "{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}"
 EndProject
+Project("{840C416C-B8F3-42BC-B0DD-F6BB14C9F8CB}") = "LumbApp Desktop", "..\LumbApp Desktop\LumbApp Desktop.aiproj", "{BFA74FF4-678D-4DEF-BCEF-78B62096248A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		All|Any CPU = All|Any CPU
@@ -40,6 +42,12 @@ Global
 		{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}.Release|x86.ActiveCfg = Release|x86
 		{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}.Release|x86.Build.0 = Release|x86
+		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.All|Any CPU.ActiveCfg = DefaultBuild
+		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.All|x86.ActiveCfg = DefaultBuild
+		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Debug|Any CPU.ActiveCfg = DefaultBuild
+		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Debug|x86.ActiveCfg = DefaultBuild
+		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Release|Any CPU.ActiveCfg = DefaultBuild
+		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Release|x86.ActiveCfg = DefaultBuild
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LumbApp/LumbApp.sln
+++ b/LumbApp/LumbApp.sln
@@ -7,8 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LumbApp", "LumbApp.csproj",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTestLumbapp", "..\UnitTestLumbapp\UnitTestLumbapp.csproj", "{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}"
 EndProject
-Project("{840C416C-B8F3-42BC-B0DD-F6BB14C9F8CB}") = "LumbApp Desktop", "..\LumbApp Desktop\LumbApp Desktop.aiproj", "{BFA74FF4-678D-4DEF-BCEF-78B62096248A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		All|Any CPU = All|Any CPU
@@ -42,12 +40,6 @@ Global
 		{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}.Release|x86.ActiveCfg = Release|x86
 		{C3FFE07A-5686-483B-8FF1-FEA36A0C8A9A}.Release|x86.Build.0 = Release|x86
-		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.All|Any CPU.ActiveCfg = DefaultBuild
-		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.All|x86.ActiveCfg = DefaultBuild
-		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Debug|Any CPU.ActiveCfg = DefaultBuild
-		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Debug|x86.ActiveCfg = DefaultBuild
-		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Release|Any CPU.ActiveCfg = DefaultBuild
-		{BFA74FF4-678D-4DEF-BCEF-78B62096248A}.Release|x86.ActiveCfg = DefaultBuild
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Pongo todas las imagenes como content y se extraen solas a la carpeta final cuando buildeamos. Tanto para las de la GUI como PDF.
Ademas, corrijo el formato de hora en el PDF